### PR TITLE
Implement no-cache

### DIFF
--- a/irods/templates/webdav/etc/varnish/default.vcl.j2
+++ b/irods/templates/webdav/etc/varnish/default.vcl.j2
@@ -15,6 +15,9 @@ sub vcl_recv {
     if (req.method != "GET" && req.method != "HEAD") {
         return (pass);
     }
+    if (req.http.Cache-Control ~ "(private|no-cache|no-store)" || req.http.Pragma == "no-cache") {
+        return (pass); 
+    }
     return (hash);
 }
 

--- a/irods/templates/webdav/etc/varnish/default.vcl.j2
+++ b/irods/templates/webdav/etc/varnish/default.vcl.j2
@@ -15,8 +15,14 @@ sub vcl_recv {
     if (req.method != "GET" && req.method != "HEAD") {
         return (pass);
     }
-    if (req.http.Cache-Control ~ "(private|no-cache|no-store)" || req.http.Pragma == "no-cache") {
+    if (req.http.Cache-Control ~ "(private|no-store)") {
+        # do not cache
         return (pass); 
+    }
+    if (req.http.Cache-Control ~ "no-cache" || req.http.Pragma == "no-cache") {
+        # do not use cache, always miss cache
+        set req.hash_always_miss = true;
+        return (hash);
     }
     return (hash);
 }


### PR DESCRIPTION
When clients provide `no-cache` header in requests, Varnish does not cache content.