### PR TITLE
Upgrade Purgeman to v0.3.0

### DIFF
--- a/irods/webdav.yml
+++ b/irods/webdav.yml
@@ -423,7 +423,7 @@
 
     - name: download purgeman package from github and uncompress
       unarchive:
-        src: https://github.com/cyverse/purgeman/releases/download/v0.2.1/purgeman_0.2.1.tar.gz
+        src: https://github.com/cyverse/purgeman/releases/download/v0.3.0/purgeman_0.3.0.tar.gz
         dest: /tmp/purgeman_setup
         remote_src: True
       register: unarchiveResp


### PR DESCRIPTION
- Retry connect to iRODS and MQ periodically (every 1min) at failure
- Purge parent directories' cache for some event types (e.g., file deletion)
- Use named queue for MQ. The queue name includes hostname
- Add version info
- Add command-line parameter for config path
- Log to file /tmp/purgeman.log