### PR TITLE
DS-471 made PG role support memory tunables

### DIFF
--- a/dbms/README.md
+++ b/dbms/README.md
@@ -13,12 +13,14 @@ Variable                            | Required | Default   | Comments
 ----------------------------------- | -------- | --------- | --------
 `dbms_checkpoint_completion_target` | no       | 0.9       | WAL checkpoint target duration fraction 
 `dbms_checkpoint_timeout`           | no       | 15        | WAL checkpoint timeout in minutes
+`dbms_effective_io_concurrency`     | no       | 200       | the number of concurrent disk I/O operations that can be executed simultaneously
 `dbms_log_line_prefix`              | no       | < %m %r > | PostgreSQL log message prefix (see PostgreSQL documentation for possible values)
 `dbms_log_min_duration`             | no       | 1000      | the number of milliseconds a query should take before it is logged in the DBMS logs. `-1` disables query logging
 `dbms_maintenance_work_mem`         | no       | 1         | the amount of memory in gibibytes for maintenance operations 
 `dbms_max_connections`              | no       | 1500      | the maximum number of connections allowed to the DBMS (change requires restart)
 `dbms_max_wal_senders`              | no       | 120       | the maximum number of walsender processes (change requires restart)
 `dbms_max_wal_size`                 | no       | 100       | the maximum size of a WAL file in gibibytes
+`dbms_mem_num_huge_pages`           | no       | 60000     | the number of huge memory pages supported by the DBMS
 `dbms_min_wal_size`                 | no       | 2         | the minimum size of a WAL file in gibibytes
 `dbms_port`                         | no       | 5432      | the TCP port used by the DBMS (change requires restart)
 `dbms_random_page_cost`             | no       | 1.0       | the query planning cost of a random page retrieval relative to other costs

--- a/dbms/README.md
+++ b/dbms/README.md
@@ -16,14 +16,14 @@ Variable                            | Required | Default   | Comments
 `dbms_effective_io_concurrency`     | no       | 200       | the number of concurrent disk I/O operations that can be executed simultaneously
 `dbms_log_line_prefix`              | no       | < %m %r > | PostgreSQL log message prefix (see PostgreSQL documentation for possible values)
 `dbms_log_min_duration`             | no       | 1000      | the number of milliseconds a query should take before it is logged in the DBMS logs. `-1` disables query logging
-`dbms_maintenance_work_mem`         | no       | 1         | the amount of memory in gibibytes for maintenance operations 
+`dbms_maintenance_work_mem`         | no       | 2         | the amount of memory in gibibytes for maintenance operations 
 `dbms_max_connections`              | no       | 1500      | the maximum number of connections allowed to the DBMS (change requires restart)
 `dbms_max_wal_senders`              | no       | 120       | the maximum number of walsender processes (change requires restart)
-`dbms_max_wal_size`                 | no       | 100       | the maximum size of a WAL file in gibibytes
+`dbms_max_wal_size`                 | no       | 8        | the maximum size of a WAL file in gibibytes
 `dbms_mem_num_huge_pages`           | no       | 60000     | the number of huge memory pages supported by the DBMS
 `dbms_min_wal_size`                 | no       | 2         | the minimum size of a WAL file in gibibytes
 `dbms_port`                         | no       | 5432      | the TCP port used by the DBMS (change requires restart)
-`dbms_random_page_cost`             | no       | 1.0       | the query planning cost of a random page retrieval relative to other costs
+`dbms_random_page_cost`             | no       | 1.1       | the query planning cost of a random page retrieval relative to other costs
 `dbms_replication_password`         | maybe*   |           | the password for authenticating `dbms_replication_user`, *this is required if replication is being set up
 `dbms_replication_start`            | no       | false     | whether or not the role should start replication. WARNING: THIS WILL DESTROY THE CURRENT REPLICA
 `dbms_replication_user`             | no       | postgres  | the DBMS user authorized to replicate the master node

--- a/dbms/group_vars/all.yml
+++ b/dbms/group_vars/all.yml
@@ -2,12 +2,14 @@
 _dbms_checkpoint_completion_target: "{{ dbms_checkpoint_completion_target | default(0.9) }}"
 _dbms_checkpoint_timeout: "{{ dbms_checkpoint_timeout | default(15) }}"
 
+_dbms_effective_io_concurrency: "{{ dbms_effective_io_concurrency | default(200) }}"
+
 _dbms_log_line_prefix: "{{ dbms_log_line_prefix | default('< %m %r >') }}"
 _dbms_log_min_duration: "{{ dbms_log_min_duration | default(1000) }}"
 
 _dbms_maintenance_work_mem: "{{ dbms_maintenance_work_mem | default(1) }}"
 
-_dbms_max_connections: "{{ dbms_max_connections | default(1500) }}"
+_dbms_max_connections: "{{ dbms_max_connections | default(500) }}"
 
 _dbms_port: "{{ dbms_port | default(5432) }}"
 
@@ -23,3 +25,5 @@ _dbms_max_wal_size: "{{ dbms_max_wal_size | default(100) }}"
 _dbms_min_wal_size: "{{ dbms_min_wal_size | default(2) }}"
 
 _dbms_work_mem: "{{ dbms_work_mem | default(32) }}MB"
+
+_dbms_mem_num_huge_pages: "{{ dbms_mem_num_huge_pages | default(60000) }}"

--- a/dbms/group_vars/all.yml
+++ b/dbms/group_vars/all.yml
@@ -7,13 +7,13 @@ _dbms_effective_io_concurrency: "{{ dbms_effective_io_concurrency | default(200)
 _dbms_log_line_prefix: "{{ dbms_log_line_prefix | default('< %m %r >') }}"
 _dbms_log_min_duration: "{{ dbms_log_min_duration | default(1000) }}"
 
-_dbms_maintenance_work_mem: "{{ dbms_maintenance_work_mem | default(1) }}"
+_dbms_maintenance_work_mem: "{{ dbms_maintenance_work_mem | default(2) }}"
 
 _dbms_max_connections: "{{ dbms_max_connections | default(500) }}"
 
 _dbms_port: "{{ dbms_port | default(5432) }}"
 
-_dbms_random_page_cost: "{{ dmbs_random_page_cost | default(1.0) }}"
+_dbms_random_page_cost: "{{ dmbs_random_page_cost | default(1.1) }}"
 
 _dbms_replication_password: "{{ dbms_replication_password | default(None) }}"
 _dbms_replication_start: "{{ dbms_replication_start | default(false) }}"
@@ -21,9 +21,9 @@ _dbms_replication_user: "{{ dbms_replication_user | default('postgres') }}"
 
 _dbms_wal_keep_segments: "{{ dbms_wal_keep_segments | default(4000) }}"
 _dbms_max_wal_senders: "{{ dbms_max_wal_senders | default(120) }}"
-_dbms_max_wal_size: "{{ dbms_max_wal_size | default(100) }}"
+_dbms_max_wal_size: "{{ dbms_max_wal_size | default(8) }}"
 _dbms_min_wal_size: "{{ dbms_min_wal_size | default(2) }}"
 
-_dbms_work_mem: "{{ dbms_work_mem | default(32) }}MB"
+_dbms_work_mem: "{{ dbms_work_mem | default(32) }}"
 
 _dbms_mem_num_huge_pages: "{{ dbms_mem_num_huge_pages | default(60000) }}"

--- a/dbms/main.yml
+++ b/dbms/main.yml
@@ -40,7 +40,7 @@
         pg_replication_user: "{{ _dbms_replication_user }}"
         pg_shared_buffers: "{{ ansible_facts['memtotal_mb']|int // 4 }}MB"
         pg_standard_conforming_strings: 'off'
-        pg_work_mem: "{{ _dbms_work_mem }}"
+        pg_work_mem: "{{ _dbms_work_mem }}MB"
         pg_effective_io_concurrency: "{{ _dbms_effective_io_concurrency }}"
         pg_max_worker_processes: "{{ max_worker_processes }}"
         pg_max_parallel_workers: "{{ max_worker_processes }}"
@@ -79,7 +79,7 @@
         pg_replication_user: "{{ _dbms_replication_user }}"
         pg_shared_buffers: "{{ ansible_facts['memtotal_mb']|int // 4 }}MB"
         pg_standard_conforming_strings: 'off'
-        pg_work_mem: "{{ _dbms_work_mem }}"
+        pg_work_mem: "{{ _dbms_work_mem }}MB"
         pg_effective_io_concurrency: "{{ _dbms_effective_io_concurrency }}"
         pg_max_worker_processes: "{{ max_worker_processes }}"
         pg_max_parallel_workers: "{{ max_worker_processes }}"

--- a/dbms/main.yml
+++ b/dbms/main.yml
@@ -19,6 +19,8 @@
   hosts: dbms_primary
   become: true
   gather_facts: false
+  vars:
+    - max_worker_processes: "{{ ansible_facts['processor_nproc'] }}"
   roles:
     - role: postgres12
       vars:
@@ -39,6 +41,14 @@
         pg_shared_buffers: "{{ ansible_facts['memtotal_mb']|int // 4 }}MB"
         pg_standard_conforming_strings: 'off'
         pg_work_mem: "{{ _dbms_work_mem }}"
+        pg_effective_io_concurrency: "{{ _dbms_effective_io_concurrency }}"
+        pg_max_worker_processes: "{{ max_worker_processes }}"
+        pg_max_parallel_workers: "{{ max_worker_processes }}"
+        pg_max_parallel_workers_per_gather: "{{ max_worker_processes|int // 10 }}"
+        pg_max_parallel_maintenance_workers: "{{ max_worker_processes|int // 10 }}"
+        pg_wal_buffers: 16MB
+        pg_num_huge_pages: "{{ _dbms_mem_num_huge_pages }}"
+        pg_huge_pages: "{{ 'on' if _dbms_mem_num_huge_pages|int > 0 else 'off' }}"
         pg_downstream_nodes: "{{ groups['dbms_replicas'] }}"
         pg_wal_keep_segments: "{{ _dbms_wal_keep_segments }}"
 
@@ -47,6 +57,8 @@
   hosts: dbms_replicas
   become: true
   gather_facts: false
+  vars:
+    - max_worker_processes: "{{ ansible_facts['processor_nproc'] }}"
   roles:
     - role: postgres12
       vars:
@@ -68,4 +80,12 @@
         pg_shared_buffers: "{{ ansible_facts['memtotal_mb']|int // 4 }}MB"
         pg_standard_conforming_strings: 'off'
         pg_work_mem: "{{ _dbms_work_mem }}"
+        pg_effective_io_concurrency: "{{ _dbms_effective_io_concurrency }}"
+        pg_max_worker_processes: "{{ max_worker_processes }}"
+        pg_max_parallel_workers: "{{ max_worker_processes }}"
+        pg_max_parallel_workers_per_gather: "{{ max_worker_processes|int // 10 }}"
+        pg_max_parallel_maintenance_workers: "{{ max_worker_processes|int // 10 }}"
+        pg_wal_buffers: 16MB
+        pg_num_huge_pages: "{{ _dbms_mem_num_huge_pages }}"
+        pg_huge_pages: "{{ 'on' if _dbms_mem_num_huge_pages|int > 0 else 'off' }}"
         pg_upstream_node: "{{ groups['dbms_primary'][0] }}"

--- a/dbms/roles/postgres12/defaults/main.yml
+++ b/dbms/roles/postgres12/defaults/main.yml
@@ -21,6 +21,8 @@ pg_effective_cache_size: 4GB
 
 pg_hot_standby_feedback: 'off'
 
+pg_effective_io_concurrency: 1
+
 pg_extra_listen_addresses: []
 pg_listen_port: 5432
 
@@ -33,8 +35,10 @@ pg_wal_keep_segments: 0
 pg_max_wal_senders: 10
 pg_min_wal_size: 80MB
 pg_max_wal_size: 1GB
+pg_wal_buffers: '-1'
 
 pg_random_page_cost: 4.0
+pg_default_statistics_target: 100
 
 pg_shared_buffers: 128MB
 
@@ -42,3 +46,11 @@ pg_standard_conforming_strings: 'on'
 
 pg_work_mem: 4MB
 pg_maintenance_work_mem: 64MB
+
+pg_max_worker_processes: 8
+pg_max_parallel_workers: 8
+pg_max_parallel_maintenance_workers: 2
+pg_max_parallel_workers_per_gather: 2
+
+pg_huge_pages: try
+pg_num_huge_pages: 0

--- a/dbms/roles/postgres12/handlers/main.yml
+++ b/dbms/roles/postgres12/handlers/main.yml
@@ -1,5 +1,8 @@
 ---
-
+- name: reboot
+  debug:
+    msg: REBOOT REQUIRED FOR SETTINGS TO TAKE
+    
 - name: restart postgres
   service:
     name: postgresql

--- a/dbms/roles/postgres12/handlers/main.yml
+++ b/dbms/roles/postgres12/handlers/main.yml
@@ -2,7 +2,7 @@
 - name: reboot
   debug:
     msg: REBOOT REQUIRED FOR SETTINGS TO TAKE
-    
+
 - name: restart postgres
   service:
     name: postgresql

--- a/dbms/roles/postgres12/tasks/configure.yml
+++ b/dbms/roles/postgres12/tasks/configure.yml
@@ -4,7 +4,7 @@
     name: vm.nr_hugepages
     value: "{{ pg_num_huge_pages }}"
     state: present
-    sysctl_set: yes
+    sysctl_set: true
   notify:
     - reboot
   tags:
@@ -15,7 +15,7 @@
     name: vm.swappiness
     value: '5'
     state: present
-    sysctl_set: yes
+    sysctl_set: true
   tags:
     - no_testing
 

--- a/dbms/roles/postgres12/tasks/configure.yml
+++ b/dbms/roles/postgres12/tasks/configure.yml
@@ -1,4 +1,15 @@
 ---
+- name: configure | ensure enough vm huge pages
+  ansible.posix.sysctl:
+    name: vm.nr_hugepages
+    value: "{{ pg_num_huge_pages }}"
+    state: present
+    sysctl_set: yes
+  notify:
+    - reboot
+  tags:
+    - no_testing
+
 - name: configure | ensure vm.swappiness is 5
   ansible.posix.sysctl:
     name: vm.swappiness

--- a/dbms/roles/postgres12/templates/cyverse.conf.j2
+++ b/dbms/roles/postgres12/templates/cyverse.conf.j2
@@ -13,13 +13,16 @@ max_connections = {{ pg_max_connections }}
 
 # - Memory -
 shared_buffers = {{ pg_shared_buffers }}
+huge_pages = {{ pg_huge_pages }}
 work_mem = {{ pg_work_mem }}
 maintenance_work_mem = {{ pg_maintenance_work_mem }}
-
 
 #------------------------------------------------------------------------------
 # WRITE-AHEAD LOG
 #------------------------------------------------------------------------------
+
+# - Settings -
+wal_buffers = {{ pg_wal_buffers }}
 
 # - Checkpoints -
 checkpoint_timeout = {{ pg_checkpoint_timeout }}
@@ -27,6 +30,12 @@ max_wal_size = {{ pg_max_wal_size }}
 min_wal_size = {{ pg_min_wal_size }}
 checkpoint_completion_target = {{ pg_checkpoint_completion_target }}
 
+# - Asynchronous Behavior -
+effective_io_concurrency = {{ pg_effective_io_concurrency }}
+max_worker_processes = {{ pg_max_worker_processes }}
+max_parallel_maintenance_workers = {{ pg_max_parallel_maintenance_workers }}
+max_parallel_workers_per_gather = {{ pg_max_parallel_workers_per_gather }}
+max_parallel_workers = {{ pg_max_parallel_workers }}
 
 #------------------------------------------------------------------------------
 # REPLICATION
@@ -44,7 +53,6 @@ hot_standby = on
 hot_standby_feedback = {{ pg_hot_standby_feedback }}
 {% endif %}
 
-
 #------------------------------------------------------------------------------
 # QUERY TUNING
 #------------------------------------------------------------------------------
@@ -53,6 +61,8 @@ hot_standby_feedback = {{ pg_hot_standby_feedback }}
 random_page_cost = {{ pg_random_page_cost }}
 effective_cache_size = {{ pg_effective_cache_size }}
 
+#- Other Planner Options -
+default_statistics_target = {{ pg_default_statistics_target }}
 
 #------------------------------------------------------------------------------
 # REPORTING AND LOGGING
@@ -63,7 +73,6 @@ log_min_duration_statement = {{ pg_log_min_duration_statement }}
 
 # - What to Log -
 log_line_prefix = '{{ pg_log_line_prefix }}'
-
 
 #------------------------------------------------------------------------------
 # VERSION AND PLATFORM COMPATIBILITY

--- a/dbms/roles/postgres12/templates/cyverse.conf.j2
+++ b/dbms/roles/postgres12/templates/cyverse.conf.j2
@@ -17,6 +17,13 @@ huge_pages = {{ pg_huge_pages }}
 work_mem = {{ pg_work_mem }}
 maintenance_work_mem = {{ pg_maintenance_work_mem }}
 
+# - Asynchronous Behavior -
+effective_io_concurrency = {{ pg_effective_io_concurrency }}
+max_worker_processes = {{ pg_max_worker_processes }}
+max_parallel_maintenance_workers = {{ pg_max_parallel_maintenance_workers }}
+max_parallel_workers_per_gather = {{ pg_max_parallel_workers_per_gather }}
+max_parallel_workers = {{ pg_max_parallel_workers }}
+
 #------------------------------------------------------------------------------
 # WRITE-AHEAD LOG
 #------------------------------------------------------------------------------
@@ -29,13 +36,6 @@ checkpoint_timeout = {{ pg_checkpoint_timeout }}
 max_wal_size = {{ pg_max_wal_size }}
 min_wal_size = {{ pg_min_wal_size }}
 checkpoint_completion_target = {{ pg_checkpoint_completion_target }}
-
-# - Asynchronous Behavior -
-effective_io_concurrency = {{ pg_effective_io_concurrency }}
-max_worker_processes = {{ pg_max_worker_processes }}
-max_parallel_maintenance_workers = {{ pg_max_parallel_maintenance_workers }}
-max_parallel_workers_per_gather = {{ pg_max_parallel_workers_per_gather }}
-max_parallel_workers = {{ pg_max_parallel_workers }}
 
 #------------------------------------------------------------------------------
 # REPLICATION

--- a/dbms/tests/main.yml
+++ b/dbms/tests/main.yml
@@ -15,34 +15,33 @@
     - name: verify config values expand correctly in cyverse.conf
       assert:
         that:
+          - cyverse_conf is search("listen_addresses = 'localhost'")
+          - cyverse_conf is search('port = 5432')
+          - cyverse_conf is search('max_connections = 100')
+          - cyverse_conf is search('shared_buffers = 128MB')
+          - cyverse_conf is search('huge_pages = try')
+          - cyverse_conf is search('work_mem = 4MB')
+          - cyverse_conf is search('maintenance_work_mem = 64MB')
+          - cyverse_conf is search('wal_buffers = -1')
+          - cyverse_conf is search('checkpoint_timeout = 5min')
+          - cyverse_conf is search('max_wal_size = 1GB')
+          - cyverse_conf is search('min_wal_size = 80MB')
           - cyverse_conf is search('checkpoint_completion_target = 0.5' | regex_escape)
           - cyverse_conf is search('effective_io_concurrency = 1')
           - cyverse_conf is search('max_worker_processes = 8')
           - cyverse_conf is search('max_parallel_maintenance_workers = 2')
           - cyverse_conf is search('max_parallel_workers_per_gather = 2')
           - cyverse_conf is search('max_parallel_workers = 8')
-          - cyverse_conf is search('checkpoint_timeout = 5min')
-          - cyverse_conf is search('effective_cache_size = 4GB')
-          - cyverse_conf is search('default_statistics_target = 100')
-          - cyverse_conf is not search('^hot_standby = ')
-          - cyverse_conf is not search('^hot_standby_feedback = ')
-          - cyverse_conf is search("listen_addresses = 'localhost'")
-          - cyverse_conf is search("log_line_prefix = '%m [%p] %q%u@%d '" | regex_escape)
-          - cyverse_conf is search('log_min_duration_statement = -1')
-          - cyverse_conf is search('maintenance_work_mem = 64MB')
-          - cyverse_conf is search('wal_buffers = -1')
-          - cyverse_conf is search('max_connections = 100')
-          - cyverse_conf is not search('^max_wal_senders =')
-          - cyverse_conf is search('max_wal_size = 1GB')
-          - cyverse_conf is search('min_wal_size = 80MB')
-          - cyverse_conf is search('port = 5432')
-          - cyverse_conf is search('random_page_cost = 4.0' | regex_escape)
-          - cyverse_conf is search('shared_buffers = 128MB')
-          - cyverse_conf is search('huge_pages = try')
-          - cyverse_conf is search('standard_conforming_strings = on')
           - cyverse_conf is not search('^max_wal_senders =')
           - cyverse_conf is not search('^wal_keep_segments =')
-          - cyverse_conf is search('work_mem = 4MB')
+          - cyverse_conf is not search('^hot_standby = ')
+          - cyverse_conf is not search('^hot_standby_feedback = ')
+          - cyverse_conf is search('random_page_cost = 4.0' | regex_escape)
+          - cyverse_conf is search('effective_cache_size = 4GB')
+          - cyverse_conf is search('default_statistics_target = 100')
+          - cyverse_conf is search('log_min_duration_statement = -1')
+          - cyverse_conf is search("log_line_prefix = '%m [%p] %q%u@%d '" | regex_escape)
+          - cyverse_conf is search('standard_conforming_strings = on')
 
     - name: test .pgpass expansion
       assert:
@@ -56,7 +55,31 @@
   tasks:
     - name: test cyverse.conf expansion, no downstream or upstream nodes
       debug:
-        msg: TODO implement
+        msg: TODO implement for {{ item }}
+      with_items:
+        - listen_addresses
+        - port
+        - max_commections
+        - shared_buffers
+        - huge_pages
+        - work_mem
+        - maintenance_work_mem
+        - wal_buffers
+        - checkpoint_timeout
+        - max_wal_size
+        - min_wal_size
+        - checkpoint_completion_target
+        - effective_io_concurrency
+        - max_worker_processes
+        - max_parallel_maintenance_workers
+        - max_parallel_workers_per_gather
+        - max_parallel_workers
+        - random_page_cost
+        - effective_cache_size
+        - default_statistics_target
+        - log_min_duration_statement
+        - log_line_prefix
+        - standard_conforming_strings
 
     - name: test cyverse.conf expansion, downstream nodes only
       debug:

--- a/dbms/tests/main.yml
+++ b/dbms/tests/main.yml
@@ -55,13 +55,13 @@
   run_once: true
   tasks:
     - debug:
-        msg: TODO test cyverse.conf expansion no downstream or upstream nodes
+        msg: TODO test cyverse.conf expansion on downstream or upstream nodes
 
     - debug:
-        msg: TODO test cyverse.conf expansion downstream nodes only
+        msg: TODO test cyverse.conf expansion on downstream nodes only
 
     - debug:
-        msg: TODO test cyverse.conf expansion upstream nodes only
+        msg: TODO test cyverse.conf expansion on upstream nodes only
         
     - debug:
         msg: TODO test pgpass expansion

--- a/dbms/tests/main.yml
+++ b/dbms/tests/main.yml
@@ -54,17 +54,21 @@
   gather_facts: false
   run_once: true
   tasks:
-    - debug:
-        msg: TODO test cyverse.conf expansion on downstream or upstream nodes
+    - name: test cyverse.conf expansion, no downstream or upstream nodes
+      debug:
+        msg: TODO implement
 
-    - debug:
-        msg: TODO test cyverse.conf expansion on downstream nodes only
+    - name: test cyverse.conf expansion, downstream nodes only
+      debug:
+        msg: TODO implement
 
-    - debug:
-        msg: TODO test cyverse.conf expansion on upstream nodes only
-        
-    - debug:
-        msg: TODO test pgpass expansion
+    - name: test cyverse.conf expansion, upstream nodes only
+      debug:
+        msg: TODO implement
+
+    - name: test pgpass expansion
+      debug:
+        msg: TODO implement
 
 
 - name: test postgresql12 role
@@ -83,26 +87,39 @@
           - "'python3-psycopg2' in ansible_facts.packages"
 
     - name: verify locale en_US.UTF-8 exists
-      shell: locale --all-locales | grep --quiet en_US.utf8
+      shell: |
+        set -e
+        if ! locales="$(mktemp)"; then
+          exit 1
+        fi
+        trap "rm --force '$locales'" EXIT
+        locale --all-locales > "$locales"
+        grep --quiet en_US.utf8 "$locales"
       changed_when: false
 
-    - debug:
-        msg: TODO test configure | ensure postgres user owns home dir
+    - name: test configure | ensure postgres user owns home dir
+      debug:
+        msg: TODO implement
 
-    - debug:
-        msg: TODO test configure | ensure archive dir exists
+    - name: test configure | ensure archive dir exists
+      debug:
+        msg: TODO implement
 
-    - debug:
-        msg: TODO test configure | cyverse.conf deposition
+    - name: test configure | cyverse.conf deposition
+      debug:
+        msg: TODO implement
 
-    - debug:
-        msg: TODO test configure | ensure block in pg_hba.conf exists
+    - name: test configure | ensure block in pg_hba.conf exists
+      debug:
+        msg: TODO implement
 
-    - debug:
-        msg: TODO test configure | pgpass deposition
+    - name: test configure | pgpass deposition
+      debug:
+        msg: TODO implement
 
-    - debug:
-        msg: TODO test replication.yml
+    - name: test replication.yml
+      debug:
+        msg: TODO implement
 
 
 - name: Test Set up primary DBMS
@@ -110,7 +127,8 @@
   gather_facts: false
   run_once: true
   tasks:
-    - debug:
+    - name: test set up primary DBMS
+      debug:
         msg: TODO implement
 
 
@@ -119,7 +137,8 @@
   gather_facts: false
   run_once: true
   tasks:
-    - debug:
+    - name: test set up replica DBMSs
+      debug:
         msg: TODO implement
 
 
@@ -128,5 +147,6 @@
   gather_facts: false
   run_once: true
   tasks:
-    - debug:
+    - name: test prepare for iRODS
+      debug:
         msg: TODO implement

--- a/dbms/tests/main.yml
+++ b/dbms/tests/main.yml
@@ -16,14 +16,21 @@
       assert:
         that:
           - cyverse_conf is search('checkpoint_completion_target = 0.5' | regex_escape)
+          - cyverse_conf is search('effective_io_concurrency = 1')
+          - cyverse_conf is search('max_worker_processes = 8')
+          - cyverse_conf is search('max_parallel_maintenance_workers = 2')
+          - cyverse_conf is search('max_parallel_workers_per_gather = 2')
+          - cyverse_conf is search('max_parallel_workers = 8')
           - cyverse_conf is search('checkpoint_timeout = 5min')
           - cyverse_conf is search('effective_cache_size = 4GB')
+          - cyverse_conf is search('default_statistics_target = 100')
           - cyverse_conf is not search('^hot_standby = ')
           - cyverse_conf is not search('^hot_standby_feedback = ')
           - cyverse_conf is search("listen_addresses = 'localhost'")
           - cyverse_conf is search("log_line_prefix = '%m [%p] %q%u@%d '" | regex_escape)
           - cyverse_conf is search('log_min_duration_statement = -1')
           - cyverse_conf is search('maintenance_work_mem = 64MB')
+          - cyverse_conf is search('wal_buffers = -1')
           - cyverse_conf is search('max_connections = 100')
           - cyverse_conf is not search('^max_wal_senders =')
           - cyverse_conf is search('max_wal_size = 1GB')
@@ -31,7 +38,9 @@
           - cyverse_conf is search('port = 5432')
           - cyverse_conf is search('random_page_cost = 4.0' | regex_escape)
           - cyverse_conf is search('shared_buffers = 128MB')
+          - cyverse_conf is search('huge_pages = try')
           - cyverse_conf is search('standard_conforming_strings = on')
+          - cyverse_conf is not search('^max_wal_senders =')
           - cyverse_conf is not search('^wal_keep_segments =')
           - cyverse_conf is search('work_mem = 4MB')
 
@@ -46,8 +55,14 @@
   run_once: true
   tasks:
     - debug:
-        msg: TODO test cyverse.conf expansion
+        msg: TODO test cyverse.conf expansion no downstream or upstream nodes
 
+    - debug:
+        msg: TODO test cyverse.conf expansion downstream nodes only
+
+    - debug:
+        msg: TODO test cyverse.conf expansion upstream nodes only
+        
     - debug:
         msg: TODO test pgpass expansion
 

--- a/dbms/tests/main.yml
+++ b/dbms/tests/main.yml
@@ -22,16 +22,16 @@
           - cyverse_conf is search('huge_pages = try')
           - cyverse_conf is search('work_mem = 4MB')
           - cyverse_conf is search('maintenance_work_mem = 64MB')
-          - cyverse_conf is search('wal_buffers = -1')
-          - cyverse_conf is search('checkpoint_timeout = 5min')
-          - cyverse_conf is search('max_wal_size = 1GB')
-          - cyverse_conf is search('min_wal_size = 80MB')
-          - cyverse_conf is search('checkpoint_completion_target = 0.5' | regex_escape)
           - cyverse_conf is search('effective_io_concurrency = 1')
           - cyverse_conf is search('max_worker_processes = 8')
           - cyverse_conf is search('max_parallel_maintenance_workers = 2')
           - cyverse_conf is search('max_parallel_workers_per_gather = 2')
           - cyverse_conf is search('max_parallel_workers = 8')
+          - cyverse_conf is search('wal_buffers = -1')
+          - cyverse_conf is search('checkpoint_timeout = 5min')
+          - cyverse_conf is search('max_wal_size = 1GB')
+          - cyverse_conf is search('min_wal_size = 80MB')
+          - cyverse_conf is search('checkpoint_completion_target = 0.5' | regex_escape)
           - cyverse_conf is not search('^max_wal_senders =')
           - cyverse_conf is not search('^wal_keep_segments =')
           - cyverse_conf is not search('^hot_standby = ')
@@ -64,16 +64,16 @@
         - huge_pages
         - work_mem
         - maintenance_work_mem
-        - wal_buffers
-        - checkpoint_timeout
-        - max_wal_size
-        - min_wal_size
-        - checkpoint_completion_target
         - effective_io_concurrency
         - max_worker_processes
         - max_parallel_maintenance_workers
         - max_parallel_workers_per_gather
         - max_parallel_workers
+        - wal_buffers
+        - checkpoint_timeout
+        - max_wal_size
+        - min_wal_size
+        - checkpoint_completion_target
         - random_page_cost
         - effective_cache_size
         - default_statistics_target

--- a/testing/ansible-tester/inventory/group_vars/dbms.yml
+++ b/testing/ansible-tester/inventory/group_vars/dbms.yml
@@ -1,5 +1,7 @@
 ---
 dbms_irods_password: "{{ irods_icat_password }}"
 
+dbms_max_connections: 10
+
 dbms_replication_password: password
 dbms_replication_user: replicator

--- a/testing/ansible-tester/inventory/host_vars/dstesting_dbms_configured_1.dstesting_default
+++ b/testing/ansible-tester/inventory/host_vars/dstesting_dbms_configured_1.dstesting_default
@@ -1,4 +1,2 @@
 ---
-package_manager: apt
-
 dbms_mem_num_huge_pages: 0

--- a/testing/ansible-tester/inventory/host_vars/dstesting_dbms_unconfigured_2.dstesting_default
+++ b/testing/ansible-tester/inventory/host_vars/dstesting_dbms_unconfigured_2.dstesting_default
@@ -1,2 +1,4 @@
 ---
 package_manager: apt
+
+dbms_mem_num_huge_pages: 0

--- a/testing/run
+++ b/testing/run
@@ -64,7 +64,7 @@ EOF
 }
 
 
-set -o errexit
+set -o errexit -o nounset -o pipefail
 
 if [[ "$OSTYPE" == "darwin"* ]]
 then
@@ -163,7 +163,7 @@ resolve_opts()
         ;;
       -p|--pretty)
         eval "$optsVar"[pretty]=pretty
-        shift 2
+        shift 1
         ;;
       -S|--setup)
         eval "$optsVar""[setup]='$2'"


### PR DESCRIPTION
1. The cyverse.conf template was expanded to include the configuration values that PGTune tunes. It also includes `huge_pages`.
2. The configure tasks now set the sysctl value `vm.rn_huge_pages` so that the number of huge pages can be configured by a deployment.