### PR TITLE
logging when environment bringup fails

### DIFF
--- a/testing/ansible-tester/test-playbook.sh
+++ b/testing/ansible-tester/test-playbook.sh
@@ -162,8 +162,8 @@ wait_for_env() {
 	local output
 	
 	printf 'waiting for environment to be ready\n'
-	if ! output=$(ansible-playbook --inventory-file="$inventory" /wait-for-ready.yml); then
-		printf 'failed to bring up the environment\n%s', "$output"
+	if ! output="$(ansible-playbook --inventory-file="$inventory" /wait-for-ready.yml)"; then
+		printf 'failed to bring up the environment\n%s' "$output"
 		return 1
 	fi
 }

--- a/testing/ansible-tester/test-playbook.sh
+++ b/testing/ansible-tester/test-playbook.sh
@@ -159,9 +159,11 @@ setup_env() {
 
 wait_for_env() {
 	local inventory="$1"
-	if ! output=$(ansible-playbook --inventory-file="$inventory" /wait-for-ready.yml); #> /dev/null
-	then
-		printf "failed to bring up the environment\n%s", "$output"
+	local output
+	
+	printf 'waiting for environment to be ready\n'
+	if ! output=$(ansible-playbook --inventory-file="$inventory" /wait-for-ready.yml); then
+		printf 'failed to bring up the environment\n%s', "$output"
 		return 1
 	fi
 }

--- a/testing/ansible-tester/test-playbook.sh
+++ b/testing/ansible-tester/test-playbook.sh
@@ -159,9 +159,11 @@ setup_env() {
 
 wait_for_env() {
 	local inventory="$1"
-
-	printf 'waiting for environment to be ready\n'
-	ansible-playbook --inventory-file="$inventory" /wait-for-ready.yml > /dev/null
+	if ! output=$(ansible-playbook --inventory-file="$inventory" /wait-for-ready.yml); #> /dev/null
+	then
+		printf "failed to bring up the environment\n%s", "$output"
+		return 1
+	fi
 }
 
 


### PR DESCRIPTION
When environment bringup fails - log the failure, print the output that contains 'play-recap' and return 1.