### PR TITLE
Disable DavDepthInfinity

### DIFF
--- a/irods/templates/webdav/etc/httpd/conf.d/davrods.j2
+++ b/irods/templates/webdav/etc/httpd/conf.d/davrods.j2
@@ -38,7 +38,6 @@ Require {{ requires[0] }}
 {%     endif %}
 
 Dav davrods-locallock
-DavDepthInfinity on
 
 {%   endif %}
 DavRodsEnvFile /etc/httpd/irods/irods_environment.json


### PR DESCRIPTION
It looks like davrods can no longer handle PROPFIND requests with a depth of infinity. Also, allowing PROPFIND requests with a depth of infinity can cause significant memory and is potentially dangerous as it can be used for DoS attach as mentioned in mod_dav documentation.