### PR TITLE
Update the current Ansible testing node to Ubuntu 22.04

### DIFF
--- a/admin/tune_networking.yml
+++ b/admin/tune_networking.yml
@@ -1,4 +1,6 @@
 ---
+# XXX - DS-580, Centos ansible_virtualization_type incorrectly identified as
+# "kvm", Ansible version upgrade required.
 - name: determine the servers that are on physical machines
   hosts: all:!unmanaged_systems:!localhost
   become: true
@@ -32,7 +34,7 @@
                 '10G' if ethtool.stdout|int >= 10000 else
                 '1G'  if ethtool.stdout|int >= 1000 else '' }}
       changed_when: false
-
+# XXX - ^^^
 
 - name: tune MTU
   hosts: physical

--- a/irods/tasks/install_plugins.yml
+++ b/irods/tasks/install_plugins.yml
@@ -1,22 +1,5 @@
 ---
-- name: Ensure netcdf plugins not installed
-  ansible.builtin.package:
-    name:
-      - irods-icommands-netcdf
-      - irods-microservice-plugin-netcdf
-      - irods-api-plugin-netcdf
-    state: absent
-
 # # XXX - netcdf is no longer accessible for iRODS 4.2.8, needs to be readded when upgrading to iRODS 4.2.11
-# - name: Ensure netcdf rpms removed
-#   ansible.builtin.file:
-#     path: /root/{{ item }}-1.0-centos{{ ansible_distribution_major_version }}.rpm
-#     state: absent
-#   with_items:
-#     - irods-icommands-netcdf
-#     - irods-microservice-plugin-netcdf
-#     - irods-api-plugin-netcdf
-
 # - name: Install NetCDF plugins
 #   ansible.builtin.yum:
 #     name:

--- a/irods/tasks/install_plugins.yml
+++ b/irods/tasks/install_plugins.yml
@@ -7,31 +7,33 @@
       - irods-api-plugin-netcdf
     state: absent
 
-- name: Ensure netcdf rpms removed
-  ansible.builtin.file:
-    path: /root/{{ item }}-1.0-centos{{ ansible_distribution_major_version }}.rpm
-    state: absent
-  with_items:
-    - irods-icommands-netcdf
-    - irods-microservice-plugin-netcdf
-    - irods-api-plugin-netcdf
+# # XXX - netcdf is no longer accessible for iRODS 4.2.8, needs to be readded when upgrading to iRODS 4.2.11
+# - name: Ensure netcdf rpms removed
+#   ansible.builtin.file:
+#     path: /root/{{ item }}-1.0-centos{{ ansible_distribution_major_version }}.rpm
+#     state: absent
+#   with_items:
+#     - irods-icommands-netcdf
+#     - irods-microservice-plugin-netcdf
+#     - irods-api-plugin-netcdf
 
-- name: Install NetCDF plugins
-  ansible.builtin.yum:
-    name:
-      - http://people.renci.org/~dmoore/irods_netcdf/packages_2021_03_24/irods-netcdf-client_modules-4.2.8.0-centos-7-x86_64.rpm
-      - http://people.renci.org/~dmoore/irods_netcdf/packages_2021_03_24/irods-netcdf-icommands-4.2.8.0-centos-7-x86_64.rpm
-      - http://people.renci.org/~dmoore/irods_netcdf/packages_2021_03_24/irods-netcdf-server_modules-4.2.8.0-centos-7-x86_64.rpm
-    state: present
+# - name: Install NetCDF plugins
+#   ansible.builtin.yum:
+#     name:
+#       - http://people.renci.org/~dmoore/irods_netcdf/packages_2021_03_24/irods-netcdf-client_modules-4.2.8.0-centos-7-x86_64.rpm
+#       - http://people.renci.org/~dmoore/irods_netcdf/packages_2021_03_24/irods-netcdf-icommands-4.2.8.0-centos-7-x86_64.rpm
+#       - http://people.renci.org/~dmoore/irods_netcdf/packages_2021_03_24/irods-netcdf-server_modules-4.2.8.0-centos-7-x86_64.rpm
+#     state: present
 
-- name: Lock NetCDF plugins to 4.2.8.0
-  community.general.yum_versionlock:
-    name:
-      - irods-netcdf-client_modules-4.2.8.0
-      - irods-netcdf-icommands-4.2.8.0
-      - irods-netcdf-server_modules-4.2.8.0
-    state: present
-# XXX - Due to https://github.com/ansible-collections/community.general/issues/4470, this isn't
-# idempotent.
-  tags: non_idempotent
-# XXX - ^^^
+# - name: Lock NetCDF plugins to 4.2.8.0
+#   community.general.yum_versionlock:
+#     name:
+#       - irods-netcdf-client_modules-4.2.8.0
+#       - irods-netcdf-icommands-4.2.8.0
+#       - irods-netcdf-server_modules-4.2.8.0
+#     state: present
+# # XXX - Due to https://github.com/ansible-collections/community.general/issues/4470, this isn't
+# # idempotent.
+#   tags: non_idempotent
+# # XXX - ^^^
+# # XXX - ^^^

--- a/irods/tests/tasks/test_install_plugins.yml
+++ b/irods/tests/tasks/test_install_plugins.yml
@@ -1,27 +1,5 @@
 ---
-- name: retrieve installed package info
-  package_facts:
-
-- name: test ensure netcdf plugins not installed
-  assert:
-    that:
-      - not "{{ item }}" in ansible_facts.packages
-  with_items:
-    - irods-icommands-netcdf
-    - irods-microservice-plugin-netcdf
-    - irods-api-plugin-netcdf
-
 # # XXX - netcdf is no longer accessible for iRODS 4.2.8, needs to be readded when upgrading to iRODS 4.2.11
-# - name: test ensure netcdf rpms removed
-#   stat:
-#     path: /root/{{ item }}-1.0-centos{{ ansible_distribution_major_version }}.rpm
-#   register: response
-#   failed_when: response.stat.exists
-#   with_items:
-#     - irods-icommands-netcdf
-#     - irods-microservice-plugin-netcdf
-#     - irods-api-plugin-netcdf
-
 # - include_tasks: test_pkg_installed.yml
 #   vars:
 #     pkg: irods-runtime

--- a/irods/tests/tasks/test_install_plugins.yml
+++ b/irods/tests/tasks/test_install_plugins.yml
@@ -11,46 +11,49 @@
     - irods-microservice-plugin-netcdf
     - irods-api-plugin-netcdf
 
-- name: test ensure netcdf rpms removed
-  stat:
-    path: /root/{{ item }}-1.0-centos{{ ansible_distribution_major_version }}.rpm
-  register: response
-  failed_when: response.stat.exists
-  with_items:
-    - irods-icommands-netcdf
-    - irods-microservice-plugin-netcdf
-    - irods-api-plugin-netcdf
+# # XXX - netcdf is no longer accessible for iRODS 4.2.8, needs to be readded when upgrading to iRODS 4.2.11
+# - name: test ensure netcdf rpms removed
+#   stat:
+#     path: /root/{{ item }}-1.0-centos{{ ansible_distribution_major_version }}.rpm
+#   register: response
+#   failed_when: response.stat.exists
+#   with_items:
+#     - irods-icommands-netcdf
+#     - irods-microservice-plugin-netcdf
+#     - irods-api-plugin-netcdf
 
-- include_tasks: test_pkg_installed.yml
-  vars:
-    pkg: irods-runtime
-    version: 4.2.8
-  with_items:
-    - irods-netcdf-client_modules
-    - irods-netcdf-icommands
-    - irods-netcdf-server_modules
+# - include_tasks: test_pkg_installed.yml
+#   vars:
+#     pkg: irods-runtime
+#     version: 4.2.8
+#   with_items:
+#     - irods-netcdf-client_modules
+#     - irods-netcdf-icommands
+#     - irods-netcdf-server_modules
 
-- name: test lock irods NetCDF package to 4.2.8.0
-  shell: |
-    set -o pipefail
-    if ! yum versionlock status | grep --quiet '{{ item }}'; then
-      printf '{{ item }} not locked\n' >&2
-      exit 1
-    elif info="$(yum --quiet list installed '{{ item }}' | tail --lines=+2)"; then
-      readarray -t versions <<< "$info"
-      for version in "${versions[@]}"; do
-        read _ verNum _ <<< "$version"
-        if ! [[ "$verNum" =~ 4\.2\.8\.0 ]]; then
-          printf 'found version %s\n' "$verNum" >&2
-          exit 1
-        fi
-      done
-    fi
-  changed_when: false
-  with_items:
-    - irods-netcdf-client_modules
-    - irods-netcdf-icommands
-    - irods-netcdf-server_modules
+# - name: test lock irods NetCDF package to 4.2.8.0
+#   shell: |
+#     set -o pipefail
+#     if ! yum versionlock status | grep --quiet '{{ item }}'; then
+#       printf '{{ item }} not locked\n' >&2
+#       exit 1
+#     elif info="$(yum --quiet list installed '{{ item }}' | tail --lines=+2)"; then
+#       readarray -t versions <<< "$info"
+#       for version in "${versions[@]}"; do
+#         read _ verNum _ <<< "$version"
+#         if ! [[ "$verNum" =~ 4\.2\.8\.0 ]]; then
+#           printf 'found version %s\n' "$verNum" >&2
+#           exit 1
+#         fi
+#       done
+#     fi
+#   changed_when: false
+#   with_items:
+#     - irods-netcdf-client_modules
+#     - irods-netcdf-icommands
+#     - irods-netcdf-server_modules
+# # XXX - ^^^
+
 
 - name: test ensure msiSetAVU microservice is absent
   stat:

--- a/testing/ansible-tester/Dockerfile
+++ b/testing/ansible-tester/Dockerfile
@@ -1,29 +1,70 @@
-FROM williamyeh/ansible:centos7
+FROM ubuntu:22.04
 
 ### Update system packages
-RUN yum --assumeyes --quiet upgrade
+ARG DEBIAN_FRONTEND=noninteractive
 
-### Install additional ansible support
-RUN yum --assumeyes --quiet install dmidecode python3 rpm-build wget
+RUN apt-get -q -y update
+RUN apt-get -q -y upgrade
+
+RUN apt-get install -q -y \
+    dmidecode \
+    python3 \
+    python3-pip \
+    gpg-agent \
+    rpm  \
+    openssh-client \
+    wget
+
 # XXX - The latest version of pip (21.3.1) is breaking on CentOS 7 without
 #       following encoding setup.
-ENV LANG=en_US.UTF-8
+ ENV LANG=en_US.UTF-8
 # XXX - ^^^
+
+# XXX - To resolve ansible.utils.display.initialize_locale (unsupported locale setting).
+ ENV LC_ALL=C
+ # XXX - ^^^
+
 RUN python3 -m pip --quiet install --upgrade pip
 RUN python3 -m pip --disable-pip-version-check --quiet install \
-  dnspython netaddr python-irodsclient requests urllib3 wheel
-# NB: ansible-core 2.12+ requires Python 3.8, which can't be installed from the
-#     epel on CentOS 7.
-RUN python3 -m pip --disable-pip-version-check --quiet install 'ansible-core<2.12'
+  dnspython netaddr python-irodsclient requests urllib3 wheel jinja2 ansible-core==2.11.12
 
 ### Install inspection support
-RUN yum --assumeyes install ca-certificates epel-release
-RUN python -m pip --quiet uninstall --yes urllib3
+RUN apt-get install -y ca-certificates
 
-ADD https://packages.irods.org/renci-irods.yum.repo /etc/yum.repos.d/renci-irods.yum.repo
+RUN wget -qO - https://packages.irods.org/irods-signing-key.asc | sudo apt-key add -
+RUN echo "deb [arch=amd64] https://packages.irods.org/apt/ bionic main" | tee /etc/apt/sources.list.d/renci-irods.list
 
-RUN rpm --import https://packages.irods.org/irods-signing-key.asc
-RUN yum --assumeyes --quiet install irods-icommands-4.2.8 postgresql
+RUN apt-get -q -y update
+COPY apt-preferences-irods /etc/apt/preferences.d/irods
+RUN wget http://nz2.archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.17_amd64.deb
+RUN apt-get install ./libssl1.1_1.1.1f-1ubuntu2.17_amd64.deb
+
+RUN mkdir irods-runtime
+WORKDIR /irods-runtime
+RUN wget https://packages.irods.org/apt/pool/bionic/main/i/irods-runtime/irods-runtime_4.2.8_amd64.deb
+RUN ar x irods-runtime_4.2.8_amd64.deb
+RUN tar xzf control.tar.gz
+RUN sed --in-place '/^Depends:/s/ libssl1.0.0,/ libssl1.1,/' control
+RUN sed --in-place '/^Depends:/s/ python/ python3/g' control
+RUN tar c control md5sums | gzip -c > control.tar.gz
+RUN pwd
+RUN ar rcs irods-runtime_hack.deb debian-binary control.tar.gz data.tar.gz
+RUN sudo apt-get install -y ./irods-runtime_hack.deb
+WORKDIR /
+
+RUN mkdir irods-icommands
+WORKDIR /irods-icommands
+RUN wget https://packages.irods.org/apt/pool/bionic/main/i/irods-icommands/irods-icommands_4.2.8_amd64.deb
+RUN ar x irods-icommands_4.2.8_amd64.deb
+RUN tar xzf control.tar.gz
+RUN sed --in-place '/^Depends:/s/ libssl1.0.0$/ libssl1.1/' control
+RUN tar c control md5sums | gzip -c > control.tar.gz
+RUN ar rcs irods-icommands_hack.deb debian-binary control.tar.gz data.tar.gz
+RUN sudo apt-get install -y ./irods-icommands_hack.deb
+WORKDIR /
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y -q postgresql
+
 RUN mkdir /root/.ssh
 
 COPY ssh-config /root/.ssh/config

--- a/testing/ansible-tester/Dockerfile
+++ b/testing/ansible-tester/Dockerfile
@@ -1,11 +1,11 @@
 FROM ubuntu:22.04
 
-### Update system packages
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get -q -y update
 RUN apt-get -q -y upgrade
 
+### Update system packages
 RUN apt-get install -q -y \
     dmidecode \
     python3 \
@@ -31,7 +31,7 @@ RUN python3 -m pip --disable-pip-version-check --quiet install \
 ### Install inspection support
 RUN apt-get install -y ca-certificates
 
-RUN wget -qO - https://packages.irods.org/irods-signing-key.asc | sudo apt-key add -
+RUN wget -qO - https://packages.irods.org/irods-signing-key.asc | apt-key add -
 RUN echo "deb [arch=amd64] https://packages.irods.org/apt/ bionic main" | tee /etc/apt/sources.list.d/renci-irods.list
 
 RUN apt-get -q -y update
@@ -49,7 +49,7 @@ RUN sed --in-place '/^Depends:/s/ python/ python3/g' control
 RUN tar c control md5sums | gzip -c > control.tar.gz
 RUN pwd
 RUN ar rcs irods-runtime_hack.deb debian-binary control.tar.gz data.tar.gz
-RUN sudo apt-get install -y ./irods-runtime_hack.deb
+RUN apt-get install -y ./irods-runtime_hack.deb
 WORKDIR /
 
 RUN mkdir irods-icommands
@@ -60,7 +60,7 @@ RUN tar xzf control.tar.gz
 RUN sed --in-place '/^Depends:/s/ libssl1.0.0$/ libssl1.1/' control
 RUN tar c control md5sums | gzip -c > control.tar.gz
 RUN ar rcs irods-icommands_hack.deb debian-binary control.tar.gz data.tar.gz
-RUN sudo apt-get install -y ./irods-icommands_hack.deb
+RUN apt-get install -y ./irods-icommands_hack.deb
 WORKDIR /
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y -q postgresql

--- a/testing/ansible-tester/Dockerfile
+++ b/testing/ansible-tester/Dockerfile
@@ -2,6 +2,9 @@ FROM ubuntu:22.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 
+# NB - To resolve ansible.utils.display.initialize_locale (unsupported locale setting) warning
+ENV LC_ALL=C
+
 ### Update system packages
 RUN apt-get -q -y update
 RUN apt-get -q -y upgrade
@@ -15,16 +18,6 @@ RUN apt-get install -q -y \
     openssh-client \
     wget
 
-# XXX - The latest version of pip (21.3.1) is breaking on CentOS 7 without
-#       following encoding setup.
- ENV LANG=en_US.UTF-8
-# XXX - ^^^
-
-# XXX - To resolve ansible.utils.display.initialize_locale (unsupported locale setting).
- ENV LC_ALL=C
- # XXX - ^^^
-
-RUN python3 -m pip --quiet install --upgrade pip
 RUN python3 -m pip --disable-pip-version-check --quiet install \
   dnspython netaddr python-irodsclient requests urllib3 wheel jinja2 ansible-core==2.11.12
 
@@ -32,7 +25,8 @@ RUN python3 -m pip --disable-pip-version-check --quiet install \
 RUN apt-get install -y ca-certificates
 
 RUN wget -qO - https://packages.irods.org/irods-signing-key.asc | apt-key add -
-RUN echo "deb [arch=amd64] https://packages.irods.org/apt/ bionic main" | tee /etc/apt/sources.list.d/renci-irods.list
+RUN echo "deb [arch=amd64] https://packages.irods.org/apt/ bionic main" \
+    > /etc/apt/sources.list.d/renci-irods.list
 
 RUN apt-get -q -y update
 COPY apt-preferences-irods /etc/apt/preferences.d/irods
@@ -62,7 +56,7 @@ RUN ar rcs irods-icommands_hack.deb debian-binary control.tar.gz data.tar.gz
 RUN apt-get install -y ./irods-icommands_hack.deb
 WORKDIR /
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y -q postgresql
+RUN apt-get install -y -q postgresql
 
 RUN mkdir /root/.ssh
 
@@ -70,7 +64,6 @@ COPY ssh-config /root/.ssh/config
 RUN chmod --recursive go-rwx /root/.ssh
 
 ARG IRODS_CLERVER_PASSWORD=rods
-
 ENV IRODS_HOST=localhost
 ENV IRODS_PASSWORD=$IRODS_CLERVER_PASSWORD
 ENV IRODS_PORT=1247

--- a/testing/ansible-tester/Dockerfile
+++ b/testing/ansible-tester/Dockerfile
@@ -2,10 +2,10 @@ FROM ubuntu:22.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 
+### Update system packages
 RUN apt-get -q -y update
 RUN apt-get -q -y upgrade
 
-### Update system packages
 RUN apt-get install -q -y \
     dmidecode \
     python3 \

--- a/testing/ansible-tester/Dockerfile
+++ b/testing/ansible-tester/Dockerfile
@@ -47,7 +47,6 @@ RUN tar xzf control.tar.gz
 RUN sed --in-place '/^Depends:/s/ libssl1.0.0,/ libssl1.1,/' control
 RUN sed --in-place '/^Depends:/s/ python/ python3/g' control
 RUN tar c control md5sums | gzip -c > control.tar.gz
-RUN pwd
 RUN ar rcs irods-runtime_hack.deb debian-binary control.tar.gz data.tar.gz
 RUN apt-get install -y ./irods-runtime_hack.deb
 WORKDIR /

--- a/testing/ansible-tester/apt-preferences-irods
+++ b/testing/ansible-tester/apt-preferences-irods
@@ -1,0 +1,3 @@
+Package: irods-*
+Pin: version 4.2.8
+Pin-Priority: 1001


### PR DESCRIPTION
netcdf is no longer accessible for iRODS 4.2.8, thus, commenting it out. But, it the package needs to be re-added when upgrading to iRODS 4.2.11.

