### PR TITLE
Delete old sftpgo db file and resource files

### DIFF
--- a/irods/sftp.yml
+++ b/irods/sftp.yml
@@ -100,6 +100,12 @@
             mode: '0660'
             remote_src: true
 
+        - name: remove old sftpgo template, openapi, static files
+          when: unarchive_resp is changed
+          file:
+            path: /tmp/sftpgo_setup/usr/share/sftpgo
+            state: absent
+
         - name: install sftpgo template, openapi, static files
           when: unarchive_resp is changed
           copy:
@@ -197,21 +203,27 @@
 
     - name: create a log dir
       file:
-        path: "/var/log/sftpgo"
+        path: /var/log/sftpgo
         state: directory
         owner: sftpgo
         mode: '0755'
 
     - name: create a work dir
       file:
-        path: "/var/lib/sftpgo"
+        path: /var/lib/sftpgo
         state: directory
         owner: sftpgo
         mode: '0750'
 
+    # remove old db file, we don't need old db because we recreate it dynamically
+    - name: remove an old sftpgo.db file
+      file:
+        path: /var/lib/sftpgo/sftpgo.db
+        state: absent
+
     - name: create a config dir
       file:
-        path: "/etc/sftpgo"
+        path: /etc/sftpgo
         state: directory
         owner: root
         mode: '0755'

--- a/irods/templates/sftp/etc/sftpgo/sftpgo.json.j2
+++ b/irods/templates/sftp/etc/sftpgo/sftpgo.json.j2
@@ -382,7 +382,7 @@
     "env": [],
     "commands": [
       {
-        "path": "/usr/local/bin/sftpgo-auth-irods",
+        "path": "/usr/bin/sftpgo-auth-irods",
         "timeout": 30,
         "env": [
           "IRODS_PROXY_USER={{ _sftpgo_irods_proxy_username }}",


### PR DESCRIPTION
The new version of SFTPGo changed db schema and resource files. The old files need to be deleted first.