### PR TITLE
Make md5 checksum computation asynchronous

### DIFF
--- a/irods/files/rule-bases/ipc-logic.re
+++ b/irods/files/rule-bases/ipc-logic.re
@@ -110,6 +110,7 @@ _ipc_getNewAVUSetting(*Orig, *Prefix, *Candidates) =
 
 # Compute the checksum of of a given replica of a given data object
 _ipc_chksumRepl(*Object, *ReplNum) {
+	*id = _ipc_getDataId(*Object)
 	*opt = '';
 	msiAddKeyValToMspStr('forceChksum', '', *opts);
 	msiAddKeyValToMspStr('replNum', str(*ReplNum), *opts);
@@ -118,7 +119,16 @@ _ipc_chksumRepl(*Object, *ReplNum) {
 		'<INST_NAME>irods_rule_engine_plugin-irods_rule_language-instance</INST_NAME>' ++
 		'<PLUSET>0s</PLUSET>' ++
 		'<EF>0s REPEAT 0 TIMES</EF>'
-  	) {msiDataObjChksum(*Object, *opts, *_)}
+  	) {
+		*dataPath = '';
+		foreach (*rec in SELECT COLL_NAME, DATA_NAME WHERE DATA_ID = '*id') {
+			*dataPath = *rec.COLL_NAME ++ '/' ++ *rec.DATA_NAME;
+		}
+
+		if (*dataPath != '') {
+			msiDataObjChksum(*dataPath, *opts, *_);
+		}
+	}
 }
 
 

--- a/irods/files/rule-bases/ipc-logic.re
+++ b/irods/files/rule-bases/ipc-logic.re
@@ -113,7 +113,12 @@ _ipc_chksumRepl(*Object, *ReplNum) {
 	*opt = '';
 	msiAddKeyValToMspStr('forceChksum', '', *opts);
 	msiAddKeyValToMspStr('replNum', str(*ReplNum), *opts);
-	msiDataObjChksum(*Object, *opts, *_);
+
+	delay(
+		'<INST_NAME>irods_rule_engine_plugin-irods_rule_language-instance</INST_NAME>' ++
+		'<PLUSET>0s</PLUSET>' ++
+		'<EF>0s REPEAT 0 TIMES</EF>'
+  	) {msiDataObjChksum(*Object, *opts, *_)}
 }
 
 

--- a/irods/files/rule-bases/ipc-logic.re
+++ b/irods/files/rule-bases/ipc-logic.re
@@ -108,27 +108,31 @@ _ipc_getNewAVUSetting(*Orig, *Prefix, *Candidates) =
 # CHECKSUMS
 #
 
-# Compute the checksum of of a given replica of a given data object
-_ipc_chksumRepl(*Object, *ReplNum) {
-	*id = _ipc_getDataId(*Object)
-	*opt = '';
+# Compute the checksum of a given replica of a given data object
+_ipc_chksumRepl(*Id, *ReplNum) {
+  *opt = '';
 	msiAddKeyValToMspStr('forceChksum', '', *opts);
 	msiAddKeyValToMspStr('replNum', str(*ReplNum), *opts);
 
+  *dataPath = '';
+  foreach (*rec in SELECT COLL_NAME, DATA_NAME WHERE DATA_ID = '*Id') {
+    *dataPath = *rec.COLL_NAME ++ '/' ++ *rec.DATA_NAME;
+  }
+
+  if (*dataPath != '') {
+    msiDataObjChksum(*dataPath, *opts, *_);
+  }
+}
+
+# Schedule a task for computing the checksum of a given replica of a given data object
+_ipc_scheduleChksumRepl(*Object, *ReplNum) {
+	*id = _ipc_getDataId(*Object)
+	
 	delay(
 		'<INST_NAME>irods_rule_engine_plugin-irods_rule_language-instance</INST_NAME>' ++
 		'<PLUSET>0s</PLUSET>' ++
 		'<EF>0s REPEAT 0 TIMES</EF>'
-  	) {
-		*dataPath = '';
-		foreach (*rec in SELECT COLL_NAME, DATA_NAME WHERE DATA_ID = '*id') {
-			*dataPath = *rec.COLL_NAME ++ '/' ++ *rec.DATA_NAME;
-		}
-
-		if (*dataPath != '') {
-			msiDataObjChksum(*dataPath, *opts, *_);
-		}
-	}
+  	) {_ipc_chksumRepl(*id, *ReplNum)}
 }
 
 
@@ -925,7 +929,7 @@ ipc_acPostProcForParallelTransferReceived(*LeafResource) {
 # 	*me = 'ipc_dataObjCreated';
 # 	*id = int(*DATA_OBJ_INFO.data_id);
 # 	_ipc_registerAction(*id, *me);
-# 	*err = errormsg(_ipc_chksumRepl(*DATA_OBJ_INFO.logical_path, 0), *msg);
+# 	*err = errormsg(_ipc_scheduleChksumRepl(*DATA_OBJ_INFO.logical_path, 0), *msg);
 # 	if (*err < 0) { writeLine('serverLog', *msg); }
 #
 # 	*err = errormsg(setAdminGroupPerm(*DATA_OBJ_INFO.logical_path), *msg);
@@ -988,7 +992,7 @@ ipc_dataObjCreated(*User, *Zone, *DATA_OBJ_INFO, *Step) {
 	}
 
 	if (*Step != 'START') {
-		*err = errormsg(_ipc_chksumRepl(*DATA_OBJ_INFO.logical_path, 0), *msg);
+		*err = errormsg(_ipc_scheduleChksumRepl(*DATA_OBJ_INFO.logical_path, 0), *msg);
 		if (*err < 0) { writeLine('serverLog', *msg); }
 
 		if (*uuid == '') {


### PR DESCRIPTION
- This makes md5 checksum compuatation asynchronous using `delay()`
- Tested locally