### PR TITLE
DS-689: Add whitelist file to SFTPGo

### DIFF
--- a/irods/README.md
+++ b/irods/README.md
@@ -82,6 +82,8 @@ Variable                                   | Required | Default                 
 `restart_irods`                            | no       | false                                |         | iRODS can be restarted on the servers having config file changes, _see below_
 `sftp_port`                                | no       | 2022                                 |         | The SFTP service port number
 `sftp_proxy_allowed`                       | no       | `[]`                                 |         | A list of network/masks for the proxy servers allowed access to the SFTP servers
+`sftp_user_host_allowed`                   | no       | `[]`                                 |         | A list of ip addresses of the user hosts allowed (whitelisted) for access to the SFTP servers
+`sftp_user_host_rejected`                  | no       | `[]`                                 |         | A list of ip addresses of the user hosts rejected (blacklisted) for access to the SFTP servers
 `sftpgo_admin_ui_port`                     | no       | 18023                                |         | The SFTPGo admin UI service port number
 `sftpgo_admin_password`                    | yes      |                                      |         | The password of the SFTPGo admin user
 `sftpgo_admin_username`                    | no       | admin                                |         | The SFTPGo admin account name

--- a/irods/files/sftp/etc/sftpgo/blacklist.json
+++ b/irods/files/sftp/etc/sftpgo/blacklist.json
@@ -1,6 +1,0 @@
-{
-    "addresses":[
-    ],
-    "networks":[
-    ]
-}

--- a/irods/files/sftp/etc/sftpgo/whitelist.json
+++ b/irods/files/sftp/etc/sftpgo/whitelist.json
@@ -1,0 +1,6 @@
+{
+    "addresses":[
+    ],
+    "networks":[
+    ]
+}

--- a/irods/files/sftp/etc/sftpgo/whitelist.json
+++ b/irods/files/sftp/etc/sftpgo/whitelist.json
@@ -1,6 +1,0 @@
-{
-    "addresses":[
-    ],
-    "networks":[
-    ]
-}

--- a/irods/group_vars/all.yml
+++ b/irods/group_vars/all.yml
@@ -115,6 +115,8 @@ _webdav_varnish_service_port: "{{ webdav_varnish_service_port | default(6081) }}
 
 _sftp_port: "{{ sftp_port | default(2022) }}"
 _sftp_proxy_allowed: "{{ sftp_proxy_allowed | default([]) }}"
+_sftp_user_host_allowed: "{{ sftp_user_host_allowed | default([]) }}"
+_sftp_user_host_rejected: "{{ sftp_user_host_rejected | default([]) }}"
 _sftpgo_admin_ui_port:  "{{ sftpgo_admin_ui_port | default(18023) }}"
 _sftpgo_vault_dir: "{{ sftpgo_vault_dir | default('/sftpgo_vault') }}"
 _sftpgo_admin_username: "{{ sftpgo_admin_username | default('admin') }}"

--- a/irods/sftp.yml
+++ b/irods/sftp.yml
@@ -173,6 +173,11 @@
         owner: root
         mode: '0755'
 
+    - name: Remove an old sftpgo blacklist file that we don't use anymore
+      ansible.builtin.file:
+        path: /etc/sftpgo/blacklist.json
+        state: absent
+
     - name: Configure sftpgo
       ansible.builtin.template:
         src: templates/sftp/etc/sftpgo/{{ item }}.j2

--- a/irods/sftp.yml
+++ b/irods/sftp.yml
@@ -185,20 +185,6 @@
       notify:
         - Restart sftpgo
 
-    # do not overwrite existing black/white lists
-    - name: Configure sftpgo black/white lists
-      ansible.builtin.copy:
-        src: files/sftp/etc/sftpgo/{{ item }}
-        dest: /etc/sftpgo/{{ item }}
-        owner: sftpgo
-        mode: '0664'
-        force: false
-      with_items:
-        - "blacklist.json"
-        - "whitelist.json"
-      notify:
-        - Restart sftpgo
-
     - name: Check if there are ssh host_keys on the host
       ansible.builtin.stat:
         path: /etc/ssh

--- a/irods/sftp.yml
+++ b/irods/sftp.yml
@@ -185,12 +185,15 @@
       notify:
         - Restart sftpgo
 
-    - name: Configure sftpgo black lists
+    - name: Configure sftpgo black/white lists
       ansible.builtin.copy:
-        src: files/sftp/etc/sftpgo/blacklist.json
-        dest: /etc/sftpgo/blacklist.json
+        src: files/sftp/etc/sftpgo/{{ item }}
+        dest: /etc/sftpgo/{{ item }}
         owner: sftpgo
         mode: '0664'
+      with_items:
+        - "blacklist.json"
+        - "whitelist.json"
       notify:
         - Restart sftpgo
 

--- a/irods/sftp.yml
+++ b/irods/sftp.yml
@@ -185,12 +185,14 @@
       notify:
         - Restart sftpgo
 
+    # do not overwrite existing black/white lists
     - name: Configure sftpgo black/white lists
       ansible.builtin.copy:
         src: files/sftp/etc/sftpgo/{{ item }}
         dest: /etc/sftpgo/{{ item }}
         owner: sftpgo
         mode: '0664'
+        force: false
       with_items:
         - "blacklist.json"
         - "whitelist.json"

--- a/irods/templates/sftp/etc/sftpgo/sftpgo.json.j2
+++ b/irods/templates/sftp/etc/sftpgo/sftpgo.json.j2
@@ -37,7 +37,7 @@
       "observation_time": 30,
       "entries_soft_limit": 100,
       "entries_hard_limit": 150,
-      "safelist_file": "",
+      "safelist_file": "/etc/sftpgo/whitelist.json",
       "blocklist_file": "/etc/sftpgo/blacklist.json",
       "safelist": [],
       "blocklist": []

--- a/irods/templates/sftp/etc/sftpgo/sftpgo.json.j2
+++ b/irods/templates/sftp/etc/sftpgo/sftpgo.json.j2
@@ -37,10 +37,20 @@
       "observation_time": 30,
       "entries_soft_limit": 100,
       "entries_hard_limit": 150,
-      "safelist_file": "/etc/sftpgo/whitelist.json",
-      "blocklist_file": "/etc/sftpgo/blacklist.json",
-      "safelist": [],
-      "blocklist": []
+      "safelist_file": "",
+      "blocklist_file": "",
+      "safelist": [
+{%- for host_allowed in _sftp_user_host_allowed %}
+{%    set ip = host_allowed if host_allowed|ansible.utils.ipaddr else lookup('dig', host_allowed) %}
+      "{{ ip }}"{% if not loop.last %},{% endif %}
+{% endfor +%}
+      ],
+      "blocklist": [
+{%- for host_rejected in _sftp_user_host_rejected %}
+{%    set ip = host_rejected if host_rejected|ansible.utils.ipaddr else lookup('dig', host_rejected) %}
+      "{{ ip }}"{% if not loop.last %},{% endif %}
+{% endfor +%}
+      ]
     },
     "rate_limiters": [
       {

--- a/irods/tests/sftp.yml
+++ b/irods/tests/sftp.yml
@@ -89,6 +89,12 @@
       register: response
       failed_when: not response.stat.exists
 
+    - name: Test whitelist.json deployed
+      ansible.builtin.stat:
+        path: /etc/sftpgo/whitelist.json
+      register: response
+      failed_when: not response.stat.exists
+
     - name: Test sftpgo system group exists
       ansible.builtin.getent:
         database: group

--- a/irods/tests/sftp.yml
+++ b/irods/tests/sftp.yml
@@ -83,18 +83,6 @@
       register: response
       failed_when: not response.stat.exists
 
-    - name: Test blacklist.json deployed
-      ansible.builtin.stat:
-        path: /etc/sftpgo/blacklist.json
-      register: response
-      failed_when: not response.stat.exists
-
-    - name: Test whitelist.json deployed
-      ansible.builtin.stat:
-        path: /etc/sftpgo/whitelist.json
-      register: response
-      failed_when: not response.stat.exists
-
     - name: Test sftpgo system group exists
       ansible.builtin.getent:
         database: group

--- a/testing/ansible-tester/inventory/group_vars/sftp.yml
+++ b/testing/ansible-tester/inventory/group_vars/sftp.yml
@@ -5,3 +5,5 @@ sftpgo_irods_proxy_username: sftp
 sftpgo_irods_proxy_password: sftp
 sftpgo_irods_auth_scheme: native
 sftp_proxy_allowed: ['1.1.1.1', '2.2.2.2/32', 'data.cyverse.org']
+sftp_user_host_allowed: []
+sftp_user_host_rejected: ['4.4.4.4']


### PR DESCRIPTION
This will add a whitelist file to SFTPGo.

The whitelist file is a json file that lists host IPs. The hosts will not be banned in any cases.
The ansible code will not overwrite existing whitelist or blacklist files as we will add new hosts to the list files on the system deployed manually. 