### PR TITLE
DS-226: irods_clerver_auth reauthentication

### DIFF
--- a/irods/library/irods_clerver_auth
+++ b/irods/library/irods_clerver_auth
@@ -33,7 +33,10 @@ main()
 
   if [ -e "$authFile" ]
   then
-    succeed false
+    if ils < /dev/null &>/dev/null
+    then
+      succeed false
+    fi
   fi
 
   if [ -n "$provider" ]


### PR DESCRIPTION
The irods_clerver_auth ansible module will authenticate the clerver user if  the iRODS authentication file exists, and if the authentication credentials have changed.