### PR TITLE
DS-690: Enforce file encryption via iRODS policy

### DIFF
--- a/irods/files/rule-bases/cyverse.re
+++ b/irods/files/rule-bases/cyverse.re
@@ -8,6 +8,34 @@
 _cyverse_HOME = '/' ++ cyverse_ZONE ++ '/home'
 
 #
+# These are string manipulation functions
+#
+
+# Determines whether or not the string in the first argument starts with the
+# string in the second argument.
+cyverse_startsWith(*Str, *Prefix) =
+	if strlen(*Str) < strlen(*Prefix) then false
+	else if substr(*Str, 0, strlen(*Prefix)) != *Prefix then false
+	else true
+
+# Determines whether or not the string in the first argument ends with the 
+# string in the second argument.
+#
+cyverse_endsWith(*str, *suffix) =
+	if strlen(*str) < strlen(*suffix) then false
+	else if substr(*str, strlen(*str) - strlen(*suffix), strlen(*str)) != *suffix then false
+	else true;
+
+# Removes a prefix from a string.
+cyverse_removePrefix(*Orig, *Prefixes) =
+	if size(*Prefixes) == 0 then *Orig
+	else
+		if cyverse_startsWith(*Orig, hd(*Prefixes))
+		then substr(*Orig, strlen(hd(*Prefixes)), strlen(*Orig))
+		else cyverse_removePrefix(*Orig, tl(*Prefixes))
+
+
+#
 # These are the constants used by iRODS to identity the type of an entity.
 #
 

--- a/irods/files/rule-bases/cyverse_core.re
+++ b/irods/files/rule-bases/cyverse_core.re
@@ -705,8 +705,9 @@ pep_api_rm_coll_except(*Instance, *Comm, *RmCollInp, *CollOprStat) {
 
 # STRUCT_FILE_EXT_AND_REG
 
-# This is the pre processing logic for when an attempt is made to delete a
-# collection through the API using a RM_COLL request.
+# This is the pre processing logic for when an attempt is made to extract a
+# struct file and register files in it through the API using a 
+# STRUCT_FILE_EXT_AND_REG request.
 #
 #  Instance                  (string) unknown
 #  Comm                      (`KeyValuePair_PI`) user connection and auth information

--- a/irods/files/rule-bases/cyverse_core.re
+++ b/irods/files/rule-bases/cyverse_core.re
@@ -496,8 +496,8 @@ acPostProcForRmColl {
 #  CollCreateInp  (`KeyValuePair_PI`) information related to the new collection
 #
 pep_api_coll_create_post(*Instance, *Comm, *CollCreateInp) {
-	ipcTrash_api_coll_create_post(*Instance, *Comm, *CollCreateInp);
 	ipcEncryption_api_coll_create_post(*Instance, *Comm, *CollCreateInp);
+	ipcTrash_api_coll_create_post(*Instance, *Comm, *CollCreateInp);
 }
 
 
@@ -569,8 +569,8 @@ pep_api_data_obj_create_post(*Instance, *Comm, *DataObjInp) {
 #  DataObjInp  (`KeyValuePair_PI`) information related to the data object
 #
 pep_api_data_obj_open_pre(*Instance, *Comm, *DataObjInp) {
-	mdrepo_api_data_obj_open_pre(*Instance, *Comm, *DataObjInp);
 	ipcEncryption_api_data_obj_open_pre(*Instance, *Comm, *DataObjInp)
+	mdrepo_api_data_obj_open_pre(*Instance, *Comm, *DataObjInp);
 }
 
 pep_api_data_obj_open_and_stat_pre(*Instance, *Comm, *DataObjInp, *OpenStat) {
@@ -632,6 +632,7 @@ pep_api_data_obj_rename_pre(*Instance, *Comm, *DataObjRenameInp) {
 #                    its old path
 #
 pep_api_data_obj_rename_post(*Instance, *Comm, *DataObjRenameInp) {
+	ipcEncryption_api_data_obj_rename_post(*Instance, *Comm, *DataObjRenameInp)
 	ipcTrash_api_data_obj_rename_post(*Instance, *Comm, *DataObjRenameInp);
 }
 

--- a/irods/files/rule-bases/cyverse_core.re
+++ b/irods/files/rule-bases/cyverse_core.re
@@ -497,10 +497,23 @@ acPostProcForRmColl {
 #
 pep_api_coll_create_post(*Instance, *Comm, *CollCreateInp) {
 	ipcTrash_api_coll_create_post(*Instance, *Comm, *CollCreateInp);
+	ipcEncryption_api_coll_create_post(*Instance, *Comm, *CollCreateInp);
 }
 
 
 # DATA_OBJ_COPY
+
+# This is the pre processing logic for when an attempt is made to copy a data
+# object through the API using a DATA_OBJ_COPY request.
+#
+#  Instance        (string) unknown
+#  Comm            (`KeyValuePair_PI`) user connection and auth information
+#  DataObjCopyInp  (`KeyValuePair_PI`) information related to copy operation
+#  TransStat       unknown
+#
+pep_api_data_obj_copy_pre(*Instance, *Comm, *DataObjCopyInp, *TransStat) {
+	ipcEncryption_api_data_obj_copy_pre(*Instance, *Comm, *DataObjCopyInp)
+}
 
 # This is the post processing logic for when a data object is copied through the
 # API using a DATA_OBJ_COPY request.
@@ -516,6 +529,22 @@ pep_api_data_obj_copy_post(*Instance, *Comm, *DataObjCopyInp, *TransStat) {
 
 
 # DATA_OBJ_CREATE
+
+# This is the pre processing logic for when an attempt is made to create a data
+# object through the API using a DATA_OBJ_CREATE request.
+#
+#  Instance    (string) unknown
+#  Comm        (`KeyValuePair_PI`) user connection and auth information
+#  DataObjInp  (`KeyValuePair_PI`) information related to the created data
+#              object
+#
+pep_api_data_obj_create_pre(*Instance, *Comm, *DataObjInp) {
+  	ipcEncryption_api_data_obj_create_pre(*Instance, *Comm, *DataObjInp)
+}
+
+pep_api_data_obj_create_and_stat_pre(*Instance, *Comm, *DataObjInp, *OpenStat) {
+  	ipcEncryption_api_data_obj_create_pre(*Instance, *Comm, *DataObjInp)
+}
 
 # This is the post processing logic for when a data object is created through
 # API using a DATA_OBJ_CREATE request.
@@ -541,6 +570,11 @@ pep_api_data_obj_create_post(*Instance, *Comm, *DataObjInp) {
 #
 pep_api_data_obj_open_pre(*Instance, *Comm, *DataObjInp) {
 	mdrepo_api_data_obj_open_pre(*Instance, *Comm, *DataObjInp);
+	ipcEncryption_api_data_obj_open_pre(*Instance, *Comm, *DataObjInp)
+}
+
+pep_api_data_obj_open_and_stat_pre(*Instance, *Comm, *DataObjInp, *OpenStat) {
+	ipcEncryption_api_data_obj_open_pre(*Instance, *Comm, *DataObjInp)
 }
 
 
@@ -556,6 +590,7 @@ pep_api_data_obj_open_pre(*Instance, *Comm, *DataObjInp) {
 #  PORTAL_OPR_OUT  unknown
 #
 pep_api_data_obj_put_pre(*Instance, *Comm, *DataObjInp, *DataObjInpBBuf, *PORTAL_OPR_OUT) {
+	ipcEncryption_api_data_obj_put_pre(*Instance, *Comm, *DataObjInp)
 	mdrepo_api_data_obj_put_pre(*Instance, *Comm, *DataObjInp, *DataObjInpBBuf, *PORTAL_OPR_OUT);
 }
 
@@ -584,6 +619,7 @@ pep_api_data_obj_put_post(*Instance, *Comm, *DataObjInp, *DataObjInpBBuf, *PORTA
 #                    its new path
 #
 pep_api_data_obj_rename_pre(*Instance, *Comm, *DataObjRenameInp) {
+	ipcEncryption_api_data_obj_rename_pre(*Instance, *Comm, *DataObjRenameInp)
 	ipcTrash_api_data_obj_rename_pre(*Instance, *Comm, *DataObjRenameInp);
 }
 
@@ -663,6 +699,20 @@ pep_api_rm_coll_pre(*Instance, *Comm, *RmCollInp, *CollOprStat) {
 #
 pep_api_rm_coll_except(*Instance, *Comm, *RmCollInp, *CollOprStat) {
 	ipcTrash_api_rm_coll_except(*Instance, *Comm, *RmCollInp, *CollOprStat);
+}
+
+
+# STRUCT_FILE_EXT_AND_REG
+
+# This is the pre processing logic for when an attempt is made to delete a
+# collection through the API using a RM_COLL request.
+#
+#  Instance                  (string) unknown
+#  Comm                      (`KeyValuePair_PI`) user connection and auth information
+#  StructFileExtAndRegInp    (`KeyValuePair_PI`) information about the struct file
+#
+pep_api_struct_file_ext_and_reg_pre(*Instance, *Comm, *StructFileExtAndRegInp) {
+	ipcEncryption_api_struct_file_ext_and_reg_pre(*Instance, *Comm, *StructFileExtAndRegInp);
 }
 
 

--- a/irods/files/rule-bases/cyverse_core.re
+++ b/irods/files/rule-bases/cyverse_core.re
@@ -14,7 +14,7 @@
 @include 'ipc-logic'
 @include 'ipc-repl'
 @include 'ipc-trash'
-
+@include 'ipc-encryption'
 
 # SERVICE SPECIFIC RULES
 #

--- a/irods/files/rule-bases/ipc-encryption.re
+++ b/irods/files/rule-bases/ipc-encryption.re
@@ -1,0 +1,85 @@
+# Encryption enforcement policy
+
+
+# Checks if encryption is required for the collection entity
+_ipcIsEncryptionRequired(*Coll) {
+  *isRequired = false;
+  *res = SELECT META_COLL_ATTR_VALUE WHERE COLL_NAME == *Coll AND META_COLL_ATTR_NAME == 'encryption.required';
+  foreach (*record in *res) {
+    *isRequired = bool(*record.META_COLL_ATTR_VALUE);
+    break;
+  }
+  *isRequired;
+}
+
+
+# This rule checks if encryption is required
+# if encryption is required, reject creating non-encrypted files
+_ipcEncryptionCheckEncryptionRequired(*Path) {
+    msiSplitPath(*Path, *parentColl, *objName);
+    # check if parent coll has encryption.required avu
+    if (_ipcIsEncryptionRequired(*parentColl)) {
+        # all encrypted files will have ".enc" extension
+        if (!_ipc_endsWith(*objName, ".enc")) {
+            # fail to prevent iRODS from creating the file without encryption
+            writeLine('serverLog', "Failed to create data object, encryption is required under *parentColl");
+            cut;
+            failmsg(-815000, 'CYVERSE ERROR:  attempt to create unencrypted data object');
+        }
+    }
+}
+
+_ipcEncryptionRejectBulkRegIfEncryptionRequired(*Path) {
+    msiSplitPath(*Path, *parentColl, *objName);
+    if (_ipcIsEncryptionRequired(*parentColl)) {
+        # we don't allow bulk registering files 
+        writeLine('serverLog', "Failed to bulk register data objects in encryption required collection *parentColl");
+        cut;
+        failmsg(-815000, 'CYVERSE ERROR:  attempt to bulk registering data objects in encryption required collection'); 
+    }
+}
+
+_ipcEncryptionCopyAVUFromParent(*Path) {
+    msiSplitPath(*Path, *parentColl, *collName);
+    if (_ipcIsEncryptionRequired(*parentColl)) {
+        # Add encryption require meta to the new coll
+        *err = errormsg(msiModAVUMetadata("-C", *Path, 'set', 'encryption.required', "true", ''), *msg);
+        if (*err < 0) { writeLine('serverLog', *msg); }
+
+        # Add encryption mode meta to the new coll
+        *res = SELECT META_COLL_ATTR_VALUE WHERE COLL_NAME == *parentColl AND META_COLL_ATTR_NAME == 'encryption.mode';
+        foreach (*record in *res) {
+            *err = errormsg(msiModAVUMetadata("-C", *Path, 'set', 'encryption.mode', *record.META_COLL_ATTR_VALUE, ''), *msg);
+            if (*err < 0) { writeLine('serverLog', *msg); }
+            break;
+        }
+    }
+}
+
+ipcEncryption_api_data_obj_create_pre(*Instance, *Comm, *DataObjInp) {
+    _ipcEncryptionCheckEncryptionRequired(*DataObjInp.obj_path);
+}
+
+ipcEncryption_api_data_obj_open_pre(*Instance, *Comm, *DataObjInp) {
+    _ipcEncryptionCheckEncryptionRequired(*DataObjInp.obj_path);
+}
+
+ipcEncryption_api_data_obj_put_pre(*Instance, *Comm, *DataObjInp) {
+    _ipcEncryptionCheckEncryptionRequired(*DataObjInp.obj_path);
+}
+
+ipcEncryption_api_data_obj_copy_pre(*Instance, *Comm, *DataObjCopyInp) {
+    _ipcEncryptionCheckEncryptionRequired(*DataObjCopyInp.dst_obj_path);
+}
+
+ipcEncryption_api_data_obj_rename_pre(*Instance, *Comm, *DataObjRenameInp) {
+    _ipcEncryptionCheckEncryptionRequired(*DataObjRenameInp.dst_obj_path);
+}
+
+ipcEncryption_api_struct_file_ext_and_reg_pre(*Instance, *Comm, *StructFileExtAndRegInp) {
+    _ipcEncryptionRejectBulkRegIfEncryptionRequired(StructFileExtAndRegInp.obj_path)
+}
+
+ipcEncryption_api_coll_create_post(*Instance, *Comm, *CollCreateInp) {
+    _ipcEncryptionCopyAVUFromParent(*CollCreateInp.coll_name)
+}

--- a/irods/files/rule-bases/ipc-encryption.re
+++ b/irods/files/rule-bases/ipc-encryption.re
@@ -5,7 +5,7 @@
 _ipcIsEncryptionRequired(*Coll) =
     let *isRequired = false in
     let *_ = foreach ( *rec in 
-            SELECT META_COLL_ATTR_VALUE WHERE COLL_NAME == *Coll AND META_COLL_ATTR_NAME == 'encryption.required'
+            SELECT META_COLL_ATTR_VALUE WHERE COLL_NAME == *Coll AND META_COLL_ATTR_NAME == 'encryption::required'
         ) { *isRequired = bool(*rec.META_COLL_ATTR_VALUE) } in
     *isRequired
 
@@ -13,7 +13,7 @@ _ipcIsEncryptionRequired(*Coll) =
 # This rule checks if encryption is required and reject creating non-encrypted files
 _ipcEncryptionCheckEncryptionRequiredForDataObj(*Path) {
     msiSplitPath(*Path, *parentColl, *objName);
-    # check if parent coll has encryption.required avu
+    # check if parent coll has encryption::required avu
     if (_ipcIsEncryptionRequired(*parentColl)) {
         # all encrypted files will have ".enc" extension
         if (!cyverse_endsWith(*objName, ".enc")) {
@@ -42,7 +42,7 @@ _ipcEncryptionCheckEncryptionRequiredForCollInternal(*Coll) {
 # This rule checks if encryption is required and reject creating collections containing non-encrypted files
 _ipcEncryptionCheckEncryptionRequiredForColl(*SrcColl, *DstColl) {
     msiSplitPath(*DstColl, *parentColl, *collName);
-    # check if parent coll has encryption.required avu
+    # check if parent coll has encryption::required avu
     if (_ipcIsEncryptionRequired(*parentColl)) {
         _ipcEncryptionCheckEncryptionRequiredForCollInternal(*SrcColl);
     }
@@ -63,11 +63,11 @@ _ipcEncryptionCopyAVUFromParentInternal(*Coll, *EncryptionMode) {
     *res = SELECT COLL_NAME WHERE COLL_NAME == *Coll || LIKE '*Coll/%';
     foreach (*record in *res) {
         # Add encryption require meta to the sub coll
-        *err = errormsg(msiModAVUMetadata(cyverse_COLL, *record.COLL_NAME, 'set', 'encryption.required', "true", ''), *msg);
+        *err = errormsg(msiModAVUMetadata(cyverse_COLL, *record.COLL_NAME, 'set', 'encryption::required', "true", ''), *msg);
         if (*err < 0) { writeLine('serverLog', *msg); }
 
         if (*EncryptionMode != '') {
-            *err = errormsg(msiModAVUMetadata(cyverse_COLL, *record.COLL_NAME, 'set', 'encryption.mode', *EncryptionMode, ''), *msg);
+            *err = errormsg(msiModAVUMetadata(cyverse_COLL, *record.COLL_NAME, 'set', 'encryption::mode', *EncryptionMode, ''), *msg);
             if (*err < 0) { writeLine('serverLog', *msg); }  
         }
     }
@@ -77,7 +77,7 @@ _ipcEncryptionCopyAVUFromParent(*Path) {
     msiSplitPath(*Path, *parentColl, *collName);
     if (_ipcIsEncryptionRequired(*parentColl)) {
         *mode = ''
-        *res = SELECT META_COLL_ATTR_VALUE WHERE COLL_NAME == *parentColl AND META_COLL_ATTR_NAME == 'encryption.mode';
+        *res = SELECT META_COLL_ATTR_VALUE WHERE COLL_NAME == *parentColl AND META_COLL_ATTR_NAME == 'encryption::mode';
         foreach (*record in *res) {
             *mode = *record.META_COLL_ATTR_VALUE;
             break;

--- a/irods/files/rule-bases/ipc-encryption.re
+++ b/irods/files/rule-bases/ipc-encryption.re
@@ -19,7 +19,7 @@ _ipcEncryptionCheckEncryptionRequiredForDataObj(*Path) {
     # check if parent coll has encryption.required avu
     if (_ipcIsEncryptionRequired(*parentColl)) {
         # all encrypted files will have ".enc" extension
-        if (!_ipc_endsWith(*objName, ".enc")) {
+        if (!cyverse_endsWith(*objName, ".enc")) {
             # fail to prevent iRODS from creating the file without encryption
             writeLine('serverLog', "Failed to create data object, encryption is required under *parentColl");
             cut;
@@ -33,7 +33,7 @@ _ipcEncryptionCheckEncryptionRequiredForCollInternal(*Coll) {
     *res = SELECT COLL_NAME, DATA_NAME WHERE COLL_NAME == *Coll;
     foreach (*record in *res) {
         # all encrypted files will have ".enc" extension
-        if (!_ipc_endsWith(*record.DATA_NAME, ".enc")) {
+        if (!cyverse_endsWith(*record.DATA_NAME, ".enc")) {
             # fail to prevent iRODS from creating the file without encryption
             writeLine('serverLog', "Failed to create data object, encryption is required under *Coll");
             cut;

--- a/irods/files/rule-bases/ipc-encryption.re
+++ b/irods/files/rule-bases/ipc-encryption.re
@@ -3,19 +3,18 @@
 
 # Checks if encryption is required for the collection entity
 _ipcIsEncryptionRequired(*Coll) {
-  *isRequired = false;
-  *res = SELECT META_COLL_ATTR_VALUE WHERE COLL_NAME == *Coll AND META_COLL_ATTR_NAME == 'encryption.required';
-  foreach (*record in *res) {
-    *isRequired = bool(*record.META_COLL_ATTR_VALUE);
-    break;
-  }
-  *isRequired;
+    *isRequired = false;
+    *res = SELECT META_COLL_ATTR_VALUE WHERE COLL_NAME == *Coll AND META_COLL_ATTR_NAME == 'encryption.required';
+    foreach (*record in *res) {
+        *isRequired = bool(*record.META_COLL_ATTR_VALUE);
+        break;
+    }
+    *isRequired;
 }
 
 
-# This rule checks if encryption is required
-# if encryption is required, reject creating non-encrypted files
-_ipcEncryptionCheckEncryptionRequired(*Path) {
+# This rule checks if encryption is required and reject creating non-encrypted files
+_ipcEncryptionCheckEncryptionRequiredForDataObj(*Path) {
     msiSplitPath(*Path, *parentColl, *objName);
     # check if parent coll has encryption.required avu
     if (_ipcIsEncryptionRequired(*parentColl)) {
@@ -29,6 +28,37 @@ _ipcEncryptionCheckEncryptionRequired(*Path) {
     }
 }
 
+_ipcEncryptionCheckEncryptionRequiredForCollInternal(*Coll) {
+    # check if src coll has non-encrypted data objects
+    *res = SELECT COLL_NAME, DATA_NAME WHERE COLL_NAME == *Coll;
+    foreach (*record in *res) {
+        # all encrypted files will have ".enc" extension
+        if (!_ipc_endsWith(*record.DATA_NAME, ".enc")) {
+            # fail to prevent iRODS from creating the file without encryption
+            writeLine('serverLog', "Failed to create data object, encryption is required under *Coll");
+            cut;
+            failmsg(-815000, 'CYVERSE ERROR:  attempt to create unencrypted data object');
+        }
+    }
+
+    *res = SELECT COLL_NAME WHERE COLL_PARENT_NAME == *Coll;
+    foreach (*record in *res) {
+        # run recursively
+        # this might be very expensive if the directory tree is very deep
+
+        _ipcEncryptionCheckEncryptionRequiredForCollInternal(*record.COLL_NAME);
+    }
+}
+
+# This rule checks if encryption is required and reject creating collections containing non-encrypted files
+_ipcEncryptionCheckEncryptionRequiredForColl(*SrcColl, *DstColl) {
+    msiSplitPath(*DstColl, *parentColl, *collName);
+    # check if parent coll has encryption.required avu
+    if (_ipcIsEncryptionRequired(*parentColl)) {
+        _ipcEncryptionCheckEncryptionRequiredForCollInternal(*SrcColl);
+    }
+}
+
 _ipcEncryptionRejectBulkRegIfEncryptionRequired(*Path) {
     msiSplitPath(*Path, *parentColl, *objName);
     if (_ipcIsEncryptionRequired(*parentColl)) {
@@ -39,47 +69,77 @@ _ipcEncryptionRejectBulkRegIfEncryptionRequired(*Path) {
     }
 }
 
+
+_ipcEncryptionCopyAVUFromParentInternal(*Coll, *EncryptionMode) {
+    # Add encryption require meta to the sub coll
+    *err = errormsg(msiModAVUMetadata("-C", *Coll, 'set', 'encryption.required', "true", ''), *msg);
+    if (*err < 0) { writeLine('serverLog', *msg); }
+
+    if (*EncryptionMode != '') {
+        *err = errormsg(msiModAVUMetadata("-C", *Coll, 'set', 'encryption.mode', *EncryptionMode, ''), *msg);
+        if (*err < 0) { writeLine('serverLog', *msg); }  
+    }
+
+    *res = SELECT COLL_NAME WHERE COLL_PARENT_NAME == *Coll;
+    foreach (*record in *res) {
+        # run recursively
+        # this might be very expensive if the directory tree is very deep
+
+        _ipcEncryptionCopyAVUFromParentInternal(*record.COLL_NAME, *EncryptionMode);
+    }
+}
+
 _ipcEncryptionCopyAVUFromParent(*Path) {
     msiSplitPath(*Path, *parentColl, *collName);
     if (_ipcIsEncryptionRequired(*parentColl)) {
-        # Add encryption require meta to the new coll
-        *err = errormsg(msiModAVUMetadata("-C", *Path, 'set', 'encryption.required', "true", ''), *msg);
-        if (*err < 0) { writeLine('serverLog', *msg); }
-
-        # Add encryption mode meta to the new coll
+        *mode = ''
         *res = SELECT META_COLL_ATTR_VALUE WHERE COLL_NAME == *parentColl AND META_COLL_ATTR_NAME == 'encryption.mode';
         foreach (*record in *res) {
-            *err = errormsg(msiModAVUMetadata("-C", *Path, 'set', 'encryption.mode', *record.META_COLL_ATTR_VALUE, ''), *msg);
-            if (*err < 0) { writeLine('serverLog', *msg); }
+            *mode = *record.META_COLL_ATTR_VALUE;
             break;
         }
+
+        _ipcEncryptionCopyAVUFromParentInternal(*Path, *mode);
     }
 }
 
 ipcEncryption_api_data_obj_create_pre(*Instance, *Comm, *DataObjInp) {
-    _ipcEncryptionCheckEncryptionRequired(*DataObjInp.obj_path);
+    _ipcEncryptionCheckEncryptionRequiredForDataObj(*DataObjInp.obj_path);
 }
 
 ipcEncryption_api_data_obj_open_pre(*Instance, *Comm, *DataObjInp) {
-    _ipcEncryptionCheckEncryptionRequired(*DataObjInp.obj_path);
+    _ipcEncryptionCheckEncryptionRequiredForDataObj(*DataObjInp.obj_path);
 }
 
 ipcEncryption_api_data_obj_put_pre(*Instance, *Comm, *DataObjInp) {
-    _ipcEncryptionCheckEncryptionRequired(*DataObjInp.obj_path);
+    _ipcEncryptionCheckEncryptionRequiredForDataObj(*DataObjInp.obj_path);
 }
 
 ipcEncryption_api_data_obj_copy_pre(*Instance, *Comm, *DataObjCopyInp) {
-    _ipcEncryptionCheckEncryptionRequired(*DataObjCopyInp.dst_obj_path);
+    _ipcEncryptionCheckEncryptionRequiredForDataObj(*DataObjCopyInp.dst_obj_path);
 }
 
 ipcEncryption_api_data_obj_rename_pre(*Instance, *Comm, *DataObjRenameInp) {
-    _ipcEncryptionCheckEncryptionRequired(*DataObjRenameInp.dst_obj_path);
+    if (int(*DataObjRenameInp.src_opr_type) == 11) {
+        # data object
+        _ipcEncryptionCheckEncryptionRequiredForDataObj(*DataObjRenameInp.dst_obj_path);
+    } else if (int(*DataObjRenameInp.src_opr_type) == 12) {
+        # collection
+        _ipcEncryptionCheckEncryptionRequiredForColl(*DataObjRenameInp.src_obj_path, *DataObjRenameInp.dst_obj_path);
+    }
+}
+
+ipcEncryption_api_data_obj_rename_post(*Instance, *Comm, *DataObjRenameInp) {
+    if (int(*DataObjRenameInp.src_opr_type) == 12) {
+        # collection
+        _ipcEncryptionCopyAVUFromParent(*DataObjRenameInp.dst_obj_path);
+    }
 }
 
 ipcEncryption_api_struct_file_ext_and_reg_pre(*Instance, *Comm, *StructFileExtAndRegInp) {
-    _ipcEncryptionRejectBulkRegIfEncryptionRequired(StructFileExtAndRegInp.obj_path)
+    _ipcEncryptionRejectBulkRegIfEncryptionRequired(StructFileExtAndRegInp.obj_path);
 }
 
 ipcEncryption_api_coll_create_post(*Instance, *Comm, *CollCreateInp) {
-    _ipcEncryptionCopyAVUFromParent(*CollCreateInp.coll_name)
+    _ipcEncryptionCopyAVUFromParent(*CollCreateInp.coll_name);
 }

--- a/irods/files/rule-bases/ipc-encryption.re
+++ b/irods/files/rule-bases/ipc-encryption.re
@@ -2,15 +2,12 @@
 
 
 # Checks if encryption is required for the collection entity
-_ipcIsEncryptionRequired(*Coll) {
-    *isRequired = false;
-    *res = SELECT META_COLL_ATTR_VALUE WHERE COLL_NAME == *Coll AND META_COLL_ATTR_NAME == 'encryption.required';
-    foreach (*record in *res) {
-        *isRequired = bool(*record.META_COLL_ATTR_VALUE);
-        break;
-    }
-    *isRequired;
-}
+_ipcIsEncryptionRequired(*Coll) =
+    let *isRequired = false in
+    let *_ = foreach ( *rec in 
+            SELECT META_COLL_ATTR_VALUE WHERE COLL_NAME == *Coll AND META_COLL_ATTR_NAME == 'encryption.required'
+        ) { *isRequired = bool(*rec.META_COLL_ATTR_VALUE) } in
+    *isRequired
 
 
 # This rule checks if encryption is required and reject creating non-encrypted files

--- a/irods/files/rule-bases/ipc-logic.re
+++ b/irods/files/rule-bases/ipc-logic.re
@@ -17,34 +17,6 @@ _ipc_contains(*Item, *List) =
 
 
 #
-# STRINGS
-#
-
-# Determines whether or not the string in the first argument starts with the
-# string in the second argument.
-_ipc_startsWith(*Str, *Prefix) =
-	if strlen(*Str) < strlen(*Prefix) then false
-	else if substr(*Str, 0, strlen(*Prefix)) != *Prefix then false
-	else true
-
-# Determines whether or not the string in the first argument ends with the 
-# string in the second argument.
-#
-_ipc_endsWith(*str, *suffix) =
-	if strlen(*str) < strlen(*suffix) then false
-	else if substr(*str, strlen(*str) - strlen(*suffix), strlen(*str)) != *suffix then false
-	else true;
-
-# Removes a prefix from a string.
-_ipc_removePrefix(*Orig, *Prefixes) =
-	if size(*Prefixes) == 0 then *Orig
-	else
-		if _ipc_startsWith(*Orig, hd(*Prefixes))
-		then substr(*Orig, strlen(hd(*Prefixes)), strlen(*Orig))
-		else _ipc_removePrefix(*Orig, tl(*Prefixes))
-
-
-#
 # ICAT IDS
 #
 
@@ -107,7 +79,7 @@ _ipc_getNewAVUSetting(*Orig, *Prefix, *Candidates) =
 	if size(*Candidates) == 0 then *Orig
 	else
 		let *candidate = hd(*Candidates) in
-		if _ipc_startsWith(*candidate, *Prefix)
+		if cyverse_startsWith(*candidate, *Prefix)
 		then substr(*candidate, 2, strlen(*candidate))
 		else _ipc_getNewAVUSetting(*Orig, *Prefix, tl(*Candidates))
 
@@ -520,7 +492,7 @@ _ipc_sendEntityRemove(*Type, *Id, *Path, *AuthorName, *AuthorZone) {
 #
 
 # Indicates whether or not an AVU is protected
-_ipc_avuProtected(*Attribute) = _ipc_startsWith(*Attribute, 'ipc')
+_ipc_avuProtected(*Attribute) = cyverse_startsWith(*Attribute, 'ipc')
 
 # Verifies that an attribute can be modified. If it can't it fails and sends an
 # error message to the caller.
@@ -736,7 +708,7 @@ ipc_acPostProcForModifyAccessControl(*RecursiveFlag, *AccessLevel, *UserName, *U
 		_ipc_registerAction(*entityId, *me);
 
 		if (_ipc_isCurrentAction(*entityId, *me)) {
-			*level = _ipc_removePrefix(*AccessLevel, list('admin:'));
+			*level = cyverse_removePrefix(*AccessLevel, list('admin:'));
 			*type = cyverse_getEntityType(*Path);
 			*userZone = if *UserZone == '' then cyverse_ZONE else *UserZone;
 			*uuid = '';

--- a/irods/files/rule-bases/ipc-logic.re
+++ b/irods/files/rule-bases/ipc-logic.re
@@ -27,6 +27,14 @@ _ipc_startsWith(*Str, *Prefix) =
 	else if substr(*Str, 0, strlen(*Prefix)) != *Prefix then false
 	else true
 
+# Determines whether or not the string in the first argument ends with the 
+# string in the second argument.
+#
+_ipc_endsWith(*str, *suffix) =
+	if strlen(*str) < strlen(*suffix) then false
+	else if substr(*str, strlen(*str) - strlen(*suffix), strlen(*str)) != *suffix then false
+	else true;
+
 # Removes a prefix from a string.
 _ipc_removePrefix(*Orig, *Prefixes) =
 	if size(*Prefixes) == 0 then *Orig

--- a/irods/tests/cfg_irods.yml
+++ b/irods/tests/cfg_irods.yml
@@ -34,6 +34,7 @@
         - hosts_config.json
         - ipc-logic.re
         - ipc-trash.re
+        - ipc-encryption.re
         - mdrepo.re
         - mdrepo-env.re
         - pire.re


### PR DESCRIPTION
This enforces file encryption when a collection has "encryption.required" attributes set "true".

When moving or copying a collection containing data objects into the encryption enforced collection, the data objects must be all encrypted. Otherwise, the action will fail (cut).


