### PR TITLE
disable rejecting bundle file extraction and registration when encryp…

### DIFF
--- a/irods/files/rule-bases/cyverse_core.re
+++ b/irods/files/rule-bases/cyverse_core.re
@@ -714,7 +714,10 @@ pep_api_rm_coll_except(*Instance, *Comm, *RmCollInp, *CollOprStat) {
 #  StructFileExtAndRegInp    (`KeyValuePair_PI`) information about the struct file
 #
 pep_api_struct_file_ext_and_reg_pre(*Instance, *Comm, *StructFileExtAndRegInp) {
-	ipcEncryption_api_struct_file_ext_and_reg_pre(*Instance, *Comm, *StructFileExtAndRegInp);
+	# we need to comment out this block
+	# StructFileExtAndRegInp variable is not properly serialized due to a bug in iRODS < v4.3
+	# Github issue: https://github.com/irods/irods/issues/7413
+	#ipcEncryption_api_struct_file_ext_and_reg_pre(*Instance, *Comm, *StructFileExtAndRegInp);
 }
 
 

--- a/irods/files/rule-bases/ipc-encryption.re
+++ b/irods/files/rule-bases/ipc-encryption.re
@@ -48,8 +48,8 @@ _ipcEncryptionCheckEncryptionRequiredForColl(*SrcColl, *DstColl) {
     }
 }
 
-_ipcEncryptionRejectBulkRegIfEncryptionRequired(*Path) {
-    msiSplitPath(*Path, *parentColl, *objName);
+_ipcEncryptionRejectBulkRegIfEncryptionRequired(*Coll) {
+    msiSplitPath(*Coll, *parentColl, *collName);
     if (_ipcIsEncryptionRequired(*parentColl)) {
         # we don't allow bulk registering files
         writeLine('serverLog', "Failed to bulk register data objects in encryption required collection *parentColl");
@@ -121,7 +121,7 @@ ipcEncryption_api_data_obj_rename_post(*Instance, *Comm, *DataObjRenameInp) {
 }
 
 ipcEncryption_api_struct_file_ext_and_reg_pre(*Instance, *Comm, *StructFileExtAndRegInp) {
-    _ipcEncryptionRejectBulkRegIfEncryptionRequired(*StructFileExtAndRegInp.obj_path);
+    _ipcEncryptionRejectBulkRegIfEncryptionRequired(*StructFileExtAndRegInp.collection_path);
 }
 
 ipcEncryption_api_coll_create_post(*Instance, *Comm, *CollCreateInp) {


### PR DESCRIPTION
This temporarily disables the rule that disables rejecting bundle file extraction and registration when encryption is enforced because there is a bug in iRODS < v4.3
