### PR TITLE
change score_no_auth to 0 in SFTPGo's defender setting to not block innocent users

### DIFF
--- a/irods/templates/sftp/etc/sftpgo/sftpgo.json.j2
+++ b/irods/templates/sftp/etc/sftpgo/sftpgo.json.j2
@@ -33,7 +33,7 @@
       "score_invalid": 2,
       "score_valid": 0,
       "score_limit_exceeded": 3,
-      "score_no_auth": 2,
+      "score_no_auth": 0,
       "observation_time": 30,
       "entries_soft_limit": 100,
       "entries_hard_limit": 150,


### PR DESCRIPTION
Change score_no_auth to 0 in SFTPGo defender configuration to not block innocent users.