### PR TITLE
allow MCP servers to access WebDAV

### DIFF
--- a/irods/files/webdav/var/www/html/robots.txt
+++ b/irods/files/webdav/var/www/html/robots.txt
@@ -1,2 +1,8 @@
+User-agent: ModelContextProtocol/1.0 (Autonomous; +https://github.com/modelcontextprotocol/servers)
+Allow: /
+
+User-agent: AIVerde/1.0
+Allow: /
+
 User-agent: *
 Disallow: /


### PR DESCRIPTION
Allow MCP servers to access WebDAV

MCP Servers will use one of these User-agent values.
- ModelContextProtocol/1.0 (Autonomous; +https://github.com/modelcontextprotocol/servers)
- AIVerde/1.0